### PR TITLE
CaseExpressionVisitor must follow the grammar

### DIFF
--- a/sdk/opendp/smartnoise/sql/parse.py
+++ b/sdk/opendp/smartnoise/sql/parse.py
@@ -319,38 +319,26 @@ class ExpressionVisitor(SqlSmallVisitor):
 class CaseExpressionVisitor(SqlSmallVisitor):
     def visitCaseBaseExpr(self, ctx):
         wxp = ctx.whenBaseExpression()
-        whenExpressions = [self.visit(we) for we in wxp] if wxp is not None else None
-        expression = (
-            ExpressionVisitor().visit(ctx.baseCaseExpr) if ctx.baseCaseExpr is not None else None
-        )
+        whenExpressions = [self.visit(we) for we in wxp]
+        expression = ExpressionVisitor().visit(ctx.baseCaseExpr)
         else_expr = ExpressionVisitor().visit(ctx.elseExpr) if ctx.elseExpr is not None else None
         return CaseExpression(expression, whenExpressions, else_expr)
 
     def visitCaseWhenExpr(self, ctx):
         wxp = ctx.whenExpression()
-        whenExpressions = [self.visit(we) for we in wxp] if wxp is not None else None
+        whenExpressions = [self.visit(we) for we in wxp]
         expression = None
         else_expr = ExpressionVisitor().visit(ctx.elseExpr) if ctx.elseExpr is not None else None
         return CaseExpression(expression, whenExpressions, else_expr)
 
     def visitWhenExpression(self, ctx):
-        expression = (
-            BooleanExpressionVisitor().visit(ctx.baseBoolExpr)
-            if ctx.baseBoolExpr is not None
-            else None
-        )
-        thenExpression = (
-            ExpressionVisitor().visit(ctx.thenExpr) if ctx.thenExpr is not None else None
-        )
+        expression = BooleanExpressionVisitor().visit(ctx.baseBoolExpr)
+        thenExpression = ExpressionVisitor().visit(ctx.thenExpr)
         return WhenExpression(expression, thenExpression)
 
     def visitWhenBaseExpression(self, ctx):
-        expression = (
-            ExpressionVisitor().visit(ctx.baseWhenExpr) if ctx.baseWhenExpr is not None else None
-        )
-        thenExpression = (
-            ExpressionVisitor().visit(ctx.thenExpr) if ctx.thenExpr is not None else None
-        )
+        expression = ExpressionVisitor().visit(ctx.baseWhenExpr)
+        thenExpression = ExpressionVisitor().visit(ctx.thenExpr)
         return WhenExpression(expression, thenExpression)
 
 


### PR DESCRIPTION
In sql/parse.py, `CaseExpressionVisitor` does not follow the grammar rules for [caseExpression](https://github.com/opendp/smartnoise-sdk/blob/1c6966ff707736e60d9d377d00229c12a53f1f87/sdk/opendp/smartnoise/sql/parser/SqlSmall.g4#L99), [whenExpression](https://github.com/opendp/smartnoise-sdk/blob/1c6966ff707736e60d9d377d00229c12a53f1f87/sdk/opendp/smartnoise/sql/parser/SqlSmall.g4#L112), [whenBaseExpression](https://github.com/opendp/smartnoise-sdk/blob/1c6966ff707736e60d9d377d00229c12a53f1f87/sdk/opendp/smartnoise/sql/parser/SqlSmall.g4#L113). 
Some expressions are declared as optional in the visitor while they are mandatory according to the grammar. 