### PR TITLE
Reuse matching expressions

### DIFF
--- a/sdk/opendp/smartnoise/_ast/ast.py
+++ b/sdk/opendp/smartnoise/_ast/ast.py
@@ -254,7 +254,7 @@ class Relation(SqlRel):
             symbol
             for name, symbol in syms_b
             if (type(symbol) is TableColumn and symbol.compare.identifier_match(colname, name))
-            or name.lower() == colname.lower()
+            or (type(symbol) is not TableColumn and name.lower() == colname.lower())
         ]
         if len(syms_c) == 1:
             return syms_c[0]

--- a/sdk/opendp/smartnoise/_ast/ast.py
+++ b/sdk/opendp/smartnoise/_ast/ast.py
@@ -254,7 +254,7 @@ class Relation(SqlRel):
             symbol
             for name, symbol in syms_b
             if (type(symbol) is TableColumn and symbol.compare.identifier_match(colname, name))
-            or (type(symbol) is not TableColumn and name.lower() == colname.lower())
+            or name == colname
         ]
         if len(syms_c) == 1:
             return syms_c[0]

--- a/tests/sdk/query/test_opt_rewrite.py
+++ b/tests/sdk/query/test_opt_rewrite.py
@@ -1,0 +1,67 @@
+import os
+from sdk.opendp.smartnoise._ast.tokens import unique
+import subprocess
+from opendp.smartnoise._ast.tokens import Column
+import pandas as pd
+
+from opendp.smartnoise.metadata import CollectionMetadata, Table, Int
+from opendp.smartnoise.sql import PrivateReader, PostgresReader, PandasReader
+from opendp.smartnoise.sql.parse import QueryParser
+
+git_root_dir = subprocess.check_output("git rev-parse --show-toplevel".split(" ")).decode("utf-8").strip()
+
+meta_path = os.path.join(git_root_dir, os.path.join("service", "datasets", "PUMS.yaml"))
+csv_path = os.path.join(git_root_dir, os.path.join("service", "datasets", "PUMS.csv"))
+
+
+
+class TestOptRewriter:
+    def test_with_censor_dims(self):
+        meta = CollectionMetadata.from_file(meta_path)
+        df = pd.read_csv(csv_path)
+        reader = PandasReader(df, meta)
+        private_reader = PrivateReader(reader, meta, 1.0)
+        query = "SELECT COUNT (*) AS foo, COUNT(DISTINCT pid) AS bar FROM PUMS.PUMS"
+        q = QueryParser(meta).query(query)
+        inner, outer = private_reader.rewrite_ast(q)
+        ne = outer.select.namedExpressions
+        assert(ne[0].expression.expression.name != 'keycount')
+        assert(ne[1].expression.expression.name == 'keycount')
+    def test_with_row_privacy(self):
+        meta = CollectionMetadata.from_file(meta_path)
+        meta['PUMS.PUMS'].row_privacy = True
+        meta['PUMS.PUMS']['pid'].is_key = False
+        df = pd.read_csv(csv_path)
+        reader = PandasReader(df, meta)
+        private_reader = PrivateReader(reader, meta, 1.0)
+        query = "SELECT COUNT (*) AS foo, COUNT(DISTINCT pid) AS bar FROM PUMS.PUMS"
+        q = QueryParser(meta).query(query)
+        inner, outer = private_reader.rewrite_ast(q)
+        ne = outer.select.namedExpressions
+        assert(ne[0].expression.expression.name == 'keycount')
+        assert(ne[1].expression.expression.name != 'keycount')
+    def test_case_sensitive(self):
+        sample = Table("PUMS", "PUMS", [
+            Int('pid', is_key=True),
+            Int('"PiD"')
+        ], 150)
+        meta = CollectionMetadata([sample], "csv")
+        reader = PostgresReader("localhost", "PUMS", "admin", "password")
+        private_reader = PrivateReader(reader, meta, 1.0)
+        query = 'SELECT COUNT (DISTINCT pid) AS foo, COUNT(DISTINCT "PiD") AS bar FROM PUMS.PUMS'
+        inner, outer = private_reader.rewrite(query)
+        ne = outer.select.namedExpressions
+        assert(ne[0].expression.expression.name == 'keycount')
+        assert(ne[1].expression.expression.name != 'keycount')
+    def test_reuse_expression(self):
+        meta = CollectionMetadata.from_file(meta_path)
+        df = pd.read_csv(csv_path)
+        reader = PandasReader(df, meta)
+        private_reader = PrivateReader(reader, meta, 1.0)
+        query = 'SELECT AVG(age), SUM(age), COUNT(age) FROM PUMS.PUMS'
+        q = QueryParser(meta).query(query)
+        inner, outer = private_reader.rewrite(query)
+        names = unique([f.name for f in outer.select.namedExpressions.find_nodes(Column)])
+        assert(len(names) == 2)
+        assert('count_age' in names)
+        assert('sum_age' in names)

--- a/tests/sdk/query/test_validate_pums.py
+++ b/tests/sdk/query/test_validate_pums.py
@@ -1,3 +1,4 @@
+from sdk.opendp.smartnoise.sql.reader.postgres import PostgresNameCompare
 import pytest
 from opendp.smartnoise._ast.validate import Validate
 from opendp.smartnoise.sql.parse import QueryParser
@@ -38,6 +39,7 @@ good_files = [f for f in validate_files if not "_fail" in f]
 bad_files = [f for f in validate_files if "_fail" in f]
 
 metadata = CollectionMetadata.from_file(meta_path)
+metadata.compare = PostgresNameCompare()
 
 
 #


### PR DESCRIPTION
Fix for #344 

Rewriter will properly re-use noise on expressions, and will keep `COUNT()` and `COUNT (DISTINCT)` separate.

Three unit tests:
1. Make sure keycount gets re-used for `COUNT (DISTINCT pid)` when reservoir sampling enabled
2. Make sure keycount gets-reused for `COUNT (*)` when `row_privacy` enabled
3. Make sure expressions are re-used when selecting `AVG`, `SUM`, and `COUNT` in the same `SELECT`