### PR TITLE
Fix engine tests

### DIFF
--- a/tests/sdk/engines/test_base_engines.py
+++ b/tests/sdk/engines/test_base_engines.py
@@ -13,8 +13,8 @@ from opendp.smartnoise.metadata import CollectionMetadata
 
 git_root_dir = subprocess.check_output("git rev-parse --show-toplevel".split(" ")).decode("utf-8").strip()
 
-meta_path = os.path.join(git_root_dir, os.path.join("service", "datasets", "PUMS.yaml"))
-csv_path = os.path.join(git_root_dir, os.path.join("service", "datasets", "PUMS.csv"))
+meta_path = os.path.join(git_root_dir, os.path.join("datasets", "PUMS.yaml"))
+csv_path = os.path.join(git_root_dir, os.path.join("datasets", "PUMS.csv"))
 
 
 class TestFromConnWithEngine:


### PR DESCRIPTION
Engine tests were pointing to PUMS in the old services directory which has been deleted.  Updating to the new path.