### PR TITLE
PrivateReader now requires Privacy object

### DIFF
--- a/eval/sneval/_aggregation.py
+++ b/eval/sneval/_aggregation.py
@@ -10,6 +10,7 @@ import os
 from snsql.sql import PandasReader, PrivateReader
 from snsql.sql._mechanisms.gaussian import Gaussian
 from pandasql import sqldf
+from snsql.sql.privacy import Privacy
 
 
 class Aggregation:
@@ -133,7 +134,7 @@ class Aggregation:
         # VAR not supported in Pandas Reader. So not needed to fetch actual on every aggregation
         if get_exact:
             actual = reader.execute(query)[1:][0][0]
-        private_reader = PrivateReader(reader, metadata, self.epsilon)
+        private_reader = PrivateReader(reader, metadata, privacy=Privacy(epsilon=self.epsilon))
         query_ast = private_reader.parse_query_string(query)
 
         noisy_values = []
@@ -157,7 +158,7 @@ class Aggregation:
         reader = PandasReader(df, metadata)
         exact_res = reader.execute(query)[1:]
 
-        private_reader = PrivateReader(reader, metadata, self.epsilon)
+        private_reader = PrivateReader(reader, metadata, privacy=Privacy(epsilon=self.epsilon))
         query_ast = private_reader.parse_query_string(query)
 
         # Distinguishing dimension and measure columns

--- a/sql/snsql/sql/private_reader.py
+++ b/sql/snsql/sql/private_reader.py
@@ -55,11 +55,7 @@ class PrivateReader(Reader):
         self,
         reader,
         metadata,
-        epsilon_per_column=1.0,
-        delta=10e-16,
-        *ignore,
         privacy=None
-
     ):
         """Create a new private reader.
 
@@ -80,7 +76,7 @@ class PrivateReader(Reader):
         if privacy:
             self.privacy = privacy
         else:
-            self.privacy = Privacy(epsilon=epsilon_per_column, delta=delta)
+            raise ValueError("Must pass in a Privacy object with privacy parameters.")
         
         self.odometer = OdometerHeterogeneous(self.privacy)
 

--- a/sql/tests/ast/test_visualize.py
+++ b/sql/tests/ast/test_visualize.py
@@ -7,6 +7,7 @@ import pandas as pd
 from pandasql import sqldf
 import math
 
+from snsql import *
 from snsql.metadata import Metadata
 from snsql.sql import PrivateReader
 from snsql.sql.reader.pandas import PandasReader
@@ -42,7 +43,7 @@ class TestAstVisualize:
         query = "SELECT SUM(age) AS my_sum FROM PUMS.PUMS GROUP BY age"
         parsed_query = QueryParser(schema).query(query)
         reader = PandasReader(df, schema)
-        private_reader = PrivateReader(reader, schema, 1.0)
+        private_reader = PrivateReader(reader, schema, privacy=Privacy(epsilon=1.0))
         inner, outer = private_reader._rewrite_ast(parsed_query)
         graph = outer.visualize(n_trunc=30)
         assert(isinstance(graph, Digraph))
@@ -53,7 +54,7 @@ class TestAstVisualize:
     def test_viz_child_nodes(self):
         query = "SELECT AVG(age) AS my_sum FROM PUMS.PUMS GROUP BY age"
         reader = PandasReader(df, schema)
-        private_reader = PrivateReader(reader, schema, 1.0)
+        private_reader = PrivateReader(reader, schema, privacy=Privacy(epsilon=1.0))
         inner, outer = private_reader._rewrite(query)
         aggfuncs = outer.find_nodes(AggFunction)
         for aggfunc in aggfuncs:

--- a/sql/tests/metadata/test_load_from.py
+++ b/sql/tests/metadata/test_load_from.py
@@ -25,6 +25,6 @@ class TestMetadataLoadFrom:
         assert(len(res) == 3)
     def test_load_from_private_reader_path(self):
         reader = PandasReader(pums, meta_path)
-        priv = PrivateReader(reader, meta_path)
+        priv = PrivateReader(reader, meta_path, privacy=Privacy(epsilon=1.0))
         res = priv.execute("SELECT COUNT(age) FROM PUMS.PUMS GROUP BY sex")
         assert(len(res) == 3)

--- a/sql/tests/private_reader/test_private_reader.py
+++ b/sql/tests/private_reader/test_private_reader.py
@@ -8,6 +8,7 @@ import pytest
 from snsql.sql.dpsu import preprocess_df_from_query, run_dpsu
 from snsql.metadata import Metadata
 from snsql.sql import PrivateReader
+from snsql import *
 from snsql.sql.reader.pandas import PandasReader
 
 git_root_dir = subprocess.check_output("git rev-parse --show-toplevel".split(" ")).decode("utf-8").strip()
@@ -44,11 +45,11 @@ class TestDPSU:
     def test_dpsu_vs_korolova(self):
         query = "SELECT ngram, COUNT(*) as n FROM reddit.reddit GROUP BY ngram ORDER BY n desc"
         reader = PandasReader(df, schema)
-        private_reader = PrivateReader(reader, schema, 3.0)
+        private_reader = PrivateReader(reader, schema, privacy=Privacy(epsilon=3.0))
         private_reader.options.max_contrib = 10
         result = private_reader.execute_df(query)
 
-        private_reader_korolova = PrivateReader(reader, schema, 3.0)
+        private_reader_korolova = PrivateReader(reader, schema, privacy=Privacy(epsilon=3.0))
         private_reader_korolova.options.dpsu = False
         private_reader_korolova.options.max_contrib = 10
         korolova_result = private_reader_korolova.execute_df(query)

--- a/sql/tests/query/test_having.py
+++ b/sql/tests/query/test_having.py
@@ -30,7 +30,7 @@ class TestBaseTypes:
         meta["PUMS.PUMS"].censor_dims = False
         df = pd.read_csv(csv_path)
         reader = PandasReader(df, meta)
-        private_reader = PrivateReader(reader, meta, 10.0, 10E-3)
+        private_reader = PrivateReader(reader, meta, privacy=Privacy(epsilon=3.0, delta=10e-3))
         cls.reader = private_reader
 
     def test_queries(self, test_databases):
@@ -83,7 +83,7 @@ class TestOtherTypes:
         meta["PUMS.PUMS"]["married"].type = "bool"
         df = pd.read_csv(csv_path)
         reader = PandasReader(df, meta)
-        private_reader = PrivateReader(reader, meta, 10.0, 10E-3)
+        private_reader = PrivateReader(reader, meta, privacy=Privacy(epsilon=10.0, delta=10e-3))
         self.reader = private_reader
 
     def test_queries(self):

--- a/sql/tests/query/test_opt_rewrite.py
+++ b/sql/tests/query/test_opt_rewrite.py
@@ -4,6 +4,7 @@ import subprocess
 from snsql._ast.tokens import Column
 import pandas as pd
 
+from snsql import *
 from snsql.metadata import Metadata, Table, Int
 from snsql.sql import PrivateReader
 from snsql.sql.reader.pandas import PandasReader
@@ -22,7 +23,7 @@ class TestOptRewriter:
         meta = Metadata.from_file(meta_path)
         df = pd.read_csv(csv_path)
         reader = PandasReader(df, meta)
-        private_reader = PrivateReader(reader, meta, 1.0)
+        private_reader = PrivateReader(reader, meta, privacy=Privacy(epsilon=3.0))
         query = "SELECT COUNT (*) AS foo, COUNT(DISTINCT pid) AS bar FROM PUMS.PUMS"
         q = QueryParser(meta).query(query)
         inner, outer = private_reader._rewrite_ast(q)
@@ -35,7 +36,7 @@ class TestOptRewriter:
         meta['PUMS.PUMS']['pid'].is_key = False
         df = pd.read_csv(csv_path)
         reader = PandasReader(df, meta)
-        private_reader = PrivateReader(reader, meta, 1.0)
+        private_reader = PrivateReader(reader, meta, privacy=Privacy(epsilon=3.0))
         query = "SELECT COUNT (*) AS foo, COUNT(DISTINCT pid) AS bar FROM PUMS.PUMS"
         q = QueryParser(meta).query(query)
         inner, outer = private_reader._rewrite_ast(q)
@@ -49,7 +50,7 @@ class TestOptRewriter:
         ], 150)
         meta = Metadata([sample], "csv")
         reader = PostgresReader("localhost", "PUMS", "admin", "password")
-        private_reader = PrivateReader(reader, meta, 1.0)
+        private_reader = PrivateReader(reader, meta, privacy=Privacy(epsilon=3.0))
         query = 'SELECT COUNT (DISTINCT pid) AS foo, COUNT(DISTINCT "PiD") AS bar FROM PUMS.PUMS'
         inner, outer = private_reader._rewrite(query)
         ne = outer.select.namedExpressions
@@ -59,7 +60,7 @@ class TestOptRewriter:
         meta = Metadata.from_file(meta_path)
         df = pd.read_csv(csv_path)
         reader = PandasReader(df, meta)
-        private_reader = PrivateReader(reader, meta, 1.0)
+        private_reader = PrivateReader(reader, meta, privacy=Privacy(epsilon=3.0))
         query = 'SELECT AVG(age), SUM(age), COUNT(age) FROM PUMS.PUMS'
         q = QueryParser(meta).query(query)
         inner, outer = private_reader._rewrite(query)

--- a/sql/tests/query/test_query.py
+++ b/sql/tests/query/test_query.py
@@ -62,12 +62,12 @@ class TestQuery:
     #     assert(rs[1][0] > rs[2][0])
     def test_group_by_noisy_typed_order(self):
         reader = PandasReader(df, schema)
-        private_reader = PrivateReader(reader, schema, 4.0)
+        private_reader = PrivateReader(reader, schema, privacy=Privacy(epsilon=4.0))
         rs = private_reader.execute_df("SELECT COUNT(*) AS c, married AS m FROM PUMS.PUMS GROUP BY married ORDER BY c")
         assert(rs['c'][0] < rs['c'][1])
     def test_group_by_noisy_typed_order_desc(self):
         reader = PandasReader(df, schema)
-        private_reader = PrivateReader(reader, schema, 4.0)
+        private_reader = PrivateReader(reader, schema, privacy=Privacy(epsilon=4.0))
         rs = private_reader.execute_df("SELECT COUNT(*) AS c, married AS m FROM PUMS.PUMS GROUP BY married ORDER BY c DESC")
         assert(rs['c'][0] > rs['c'][1])
     def test_count_no_rows_exact_typed(self):
@@ -87,6 +87,6 @@ class TestQuery:
         assert(trs['age_total'][0] > 1000)
     def test_sum_noisy_postprocess(self):
         reader = PandasReader(df, schema)
-        private_reader = PrivateReader(reader, schema, 1.0)
+        private_reader = PrivateReader(reader, schema, privacy=Privacy(epsilon=1.0))
         trs = private_reader.execute_df("SELECT POWER(SUM(age), 2) as age_total FROM PUMS.PUMS")
         assert(trs['age_total'][0] > 1000 ** 2)

--- a/sql/tests/query/test_query_error.py
+++ b/sql/tests/query/test_query_error.py
@@ -10,6 +10,7 @@ import math
 from snsql.metadata import Metadata
 from snsql.sql import PrivateReader
 from snsql.sql.reader.pandas import PandasReader
+from snsql import *
 
 git_root_dir = subprocess.check_output("git rev-parse --show-toplevel".split(" ")).decode("utf-8").strip()
 
@@ -24,25 +25,25 @@ class TestQueryError:
         s = copy.copy(schema)
         s["PUMS.PUMS"]["income"].upper = None
         reader = PandasReader(df, s)
-        private_reader = PrivateReader(reader, s, 4.0)
+        private_reader = PrivateReader(reader, s, privacy=Privacy(epsilon=4.0))
         with pytest.raises(ValueError):
             rs = private_reader.execute_df("SELECT SUM(income) FROM PUMS.PUMS")
     def test_err2(self):
         s = copy.copy(schema)
         s["PUMS.PUMS"]["income"].lower = None
         reader = PandasReader(df, s)
-        private_reader = PrivateReader(reader, s, 4.0)
+        private_reader = PrivateReader(reader, s, privacy=Privacy(epsilon=4.0))
         with pytest.raises(ValueError):
             rs = private_reader.execute_df("SELECT income, SUM(income) FROM PUMS.PUMS GROUP BY income")
     def test_ok1(self):
         s = copy.copy(schema)
         s["PUMS.PUMS"]["income"].upper = None
         reader = PandasReader(df, s)
-        private_reader = PrivateReader(reader, s, 4.0)
+        private_reader = PrivateReader(reader, s, privacy=Privacy(epsilon=4.0))
         rs = private_reader.execute_df("SELECT income FROM PUMS.PUMS GROUP BY income")
     def test_ok2(self):
         s = copy.copy(schema)
         s["PUMS.PUMS"]["income"].upper = None
         reader = PandasReader(df, s)
-        private_reader = PrivateReader(reader, s, 4.0)
+        private_reader = PrivateReader(reader, s, privacy=Privacy(epsilon=4.0))
         rs = private_reader.execute_df("SELECT COUNT(income) FROM PUMS.PUMS")

--- a/sql/tests/query/test_thresholds.py
+++ b/sql/tests/query/test_thresholds.py
@@ -84,7 +84,7 @@ class TestQueryThresholds:
         schema_no_dpsu = copy.copy(schema)
         schema_no_dpsu["PUMS.PUMS"].use_dpsu = False
         reader = PandasReader(df, schema_no_dpsu)
-        private_reader = PrivateReader(reader, schema_no_dpsu, 1.0)
+        private_reader = PrivateReader(reader, schema_no_dpsu, privacy=Privacy(epsilon=1.0))
         assert(private_reader._options.use_dpsu == False)
         query = QueryParser(schema_no_dpsu).queries("SELECT COUNT(*) AS c FROM PUMS.PUMS GROUP BY married")[0]
         assert(private_reader._get_reader(query) is private_reader.reader)
@@ -117,7 +117,7 @@ class TestQueryThresholds:
         schema_all['PUMS.PUMS'].censor_dims = False
         reader = PandasReader(df, schema)
         query = QueryParser(schema).queries("SELECT COUNT(*) as c FROM PUMS.PUMS WHERE age > 100")[0]
-        private_reader = PrivateReader(reader, schema_all, 1.0)
+        private_reader = PrivateReader(reader, schema_all, privacy=Privacy(epsilon=1.0))
         private_reader._execute_ast(query, True)
         for i in range(3):
             print(private_reader._options)

--- a/sql/tests/query/test_top.py
+++ b/sql/tests/query/test_top.py
@@ -26,7 +26,7 @@ class TestTopAndLimit:
         meta["PUMS.PUMS"].censor_dims = False
         df = pd.read_csv(csv_path)
         reader = PandasReader(df, meta)
-        private_reader = PrivateReader(reader, meta, 10.0, 0.1)
+        private_reader = PrivateReader(reader, meta, privacy=Privacy(epsilon=3.0, delta=1.0))
         cls.reader = private_reader
     def test_order_limit(self, test_databases):
         """

--- a/sql/tests/xpath/test_xpath.py
+++ b/sql/tests/xpath/test_xpath.py
@@ -7,6 +7,7 @@ from snsql.metadata import Metadata
 from snsql.sql import PrivateReader
 from snsql.sql.reader.base import SqlReader
 from snsql.sql.parse import QueryParser
+from snsql import *
 
 git_root_dir = subprocess.check_output("git rev-parse --show-toplevel".split(" ")).decode("utf-8").strip()
 
@@ -22,7 +23,7 @@ pums = pd.read_csv(csv_path)
 query = 'SELECT AVG(age) + 3, STD(age), VAR(age), SUM(age) / 10, COUNT(age) + 2 FROM PUMS.PUMS'
 q = QueryParser(meta).query(query)
 reader = SqlReader.from_connection(pums, "pandas", metadata=meta)
-priv = PrivateReader(reader, meta, 1.0)
+priv = PrivateReader(reader, meta, privacy=Privacy(epsilon=1.0))
 subquery, root = priv._rewrite(query)
 
 class TestXPathExecutionNoRewrite:


### PR DESCRIPTION
We deprecated the `epsilon` and `delta` parameters on `PrivateReader` in the old package, instead preferring callers to pass in `Privacy` object.  There is no reason to keep the old calling pattern in the new package.