### PR TITLE
Small synthesizer fixes

### DIFF
--- a/synth/snsynth/mwem.py
+++ b/synth/snsynth/mwem.py
@@ -14,7 +14,7 @@ class MWEMSynthesizer(SDGYMBaseSynthesizer):
 
     def __init__(
         self,
-        epsilon,
+        epsilon=3.0,
         q_count=400,
         iterations=30,
         mult_weights_iterations=20,
@@ -121,6 +121,17 @@ class MWEMSynthesizer(SDGYMBaseSynthesizer):
             raise ValueError("Data must be a numpy array or pandas dataframe.")
         if self.split_factor is not None and self.splits == []:
             self.splits = self._generate_splits(data.T.shape[0], self.split_factor)
+        elif self.split_factor is None and self.splits == []:
+            # Set split factor to default to shape[1]
+            self.split_factor = data.shape[1]
+            warnings.warn(
+                    "Unset split_factor and splits, defaulting to include all columns "
+                    + "- this can lead to slow performance or out of memory error. "
+                    + " split_factor: " + str(self.split_factor),
+                    Warning,
+                )
+            self.splits = self._generate_splits(data.T.shape[0], self.split_factor)
+
         self.splits = np.array(self.splits)
         if self.splits.size == 0:
             self.histograms = self._histogram_from_data_attributes(
@@ -183,7 +194,7 @@ class MWEMSynthesizer(SDGYMBaseSynthesizer):
         # Reorder the columns to mirror their original order
         r = self._reorder(self.splits)
         if self.pandas:
-            df = pd.DataFrame(combined[:, r], index=self.pd_index, columns=self.pd_cols)
+            df = pd.DataFrame(combined[:, r], columns=self.pd_cols)
             return df
         else:
             return combined[:, r]

--- a/synth/snsynth/pytorch/pytorch_synthesizer.py
+++ b/synth/snsynth/pytorch/pytorch_synthesizer.py
@@ -36,7 +36,7 @@ class PytorchDPSynthesizer(SDGYMBaseSynthesizer):
 
     @wraps(SDGYMBaseSynthesizer.fit)
     def fit(self, data, categorical_columns=tuple(), ordinal_columns=tuple()):
-        def column_names (n_items, prefix = 'col'):
+        def column_names(n_items, prefix='col'):
             names = []
             for i in range(n_items):
                 names.append(prefix + '_' + str(i))

--- a/synth/snsynth/pytorch/pytorch_synthesizer.py
+++ b/synth/snsynth/pytorch/pytorch_synthesizer.py
@@ -2,6 +2,7 @@ from functools import wraps
 
 import numpy as np
 import pandas as pd
+import warnings
 
 from snsynth.preprocessors.preprocessing import GeneralTransformer
 from snsynth.base import SDGYMBaseSynthesizer
@@ -35,8 +36,25 @@ class PytorchDPSynthesizer(SDGYMBaseSynthesizer):
 
     @wraps(SDGYMBaseSynthesizer.fit)
     def fit(self, data, categorical_columns=tuple(), ordinal_columns=tuple()):
+        def column_names (n_items, prefix = 'col'):
+            names = []
+            for i in range(n_items):
+                names.append(prefix + '_' + str(i))
+            return names
+
         if isinstance(data, pd.DataFrame):
             self._data_columns = data.columns
+        elif isinstance(data, np.ndarray):
+            placeholder_columns = column_names(data.shape[1])
+            data = pd.DataFrame(data, columns=placeholder_columns).infer_objects()
+            self._data_columns = placeholder_columns
+            warnings.warn(
+                    "Data is numpy array, converting to pandas dataframe with default "
+                    + "column names. Inferring data types. Note: for best performance, "
+                    + "pandas dataframe should be constructed by user and "
+                    + "data_types should be specified beforehand. Dtypes: " + str(data.dtypes),
+                    Warning,
+                )
 
         self.dtypes = data.dtypes
 

--- a/synth/tests/test_mwem.py
+++ b/synth/tests/test_mwem.py
@@ -18,6 +18,10 @@ nf = df.to_numpy().astype(int)
 
 synth = MWEMSynthesizer(3., split_factor=3)
 
+synth_df = MWEMSynthesizer(3., split_factor=3)
+
+synth_default_params = MWEMSynthesizer()
+
 faux_synth = MWEMSynthesizer(3., split_factor=1)
 
 test_data = np.array([[1,1,1],[2,2,2],[3,3,3]])
@@ -45,6 +49,27 @@ class TestMWEM:
     def test_sample(self):
         sample_size = nf.shape[0]
         synthetic = synth.sample(sample_size)
+        assert synthetic.shape == nf.shape
+
+    def test_sample_different_sizes(self):
+        sample_size = int(nf.shape[0] / 2)
+        synthetic = synth.sample(sample_size)
+        assert synthetic.shape[0] == int(nf.shape[0] / 2)
+
+        synth_df.fit(df)
+        assert synth_df.histograms
+
+        synthetic = synth_df.sample(sample_size)
+        assert synthetic.shape[0] == int(df.shape[0] / 2)
+
+        sample_size = int(nf.shape[0] * 2)
+        synthetic = synth_df.sample(sample_size)
+        assert synthetic.shape[0] == int(df.shape[0] * 2)
+
+    def test_sample_default_params(self):
+        synth_default_params.fit(nf)
+        sample_size = nf.shape[0]
+        synthetic = synth_default_params.sample(sample_size)
         assert synthetic.shape == nf.shape
 
     def test_initialize_a(self):

--- a/synth/tests/test_pytorch_synthesizer.py
+++ b/synth/tests/test_pytorch_synthesizer.py
@@ -23,6 +23,8 @@ csv_path = os.path.join(git_root_dir, os.path.join("datasets", "PUMS_pid.csv"))
 
 df = pd.read_csv(csv_path)
 
+nf = df.to_numpy()
+
 @pytest.mark.torch
 class TestPytorchDPSynthesizer_DPGAN:
     def setup(self):
@@ -53,6 +55,10 @@ class TestPytorchDPSynthesizer_DPCTGAN:
         sample_size = len(df)
         synth_data = self.dpctgan.sample(sample_size)
         assert synth_data.shape == df.shape
+    
+    def test_fit_numpy(self):
+        self.dpctgan.fit(nf)
+        assert self.dpctgan.gan._generator
 
 class TestPytorchDPSynthesizer_PATECTGAN:
     def setup(self):


### PR DESCRIPTION
Made changes to fix odd mwem sampling, allow numpy as data type for pytorch_dp_synths:

- [x] MWEM trained from a dataframe seems to require sample() to use the same number of rows as training, so it needs numpy array
- [x] * MWEM seemingly requires split_factor to be set; it throws a strange error when unset
- [x] * PATE-CTGAN and DP-CTGAN don’t seem to allow numpy arrays, but work fine with pandas