### PR TITLE
DRAFT:fix_load_meta

### DIFF
--- a/sql/snsql/_ast/ast.py
+++ b/sql/snsql/_ast/ast.py
@@ -60,11 +60,28 @@ class Query(SqlRel):
             self.sample_max_ids = any(tc.sample_max_ids for tc in tables)
             self.row_privacy = any(tc.row_privacy for tc in tables)
             self.censor_dims = any(tc.censor_dims for tc in tables)
-            
+
         # get grouping expression symbols
         self._grouping_symbols = []
         if self.agg:
-            self._grouping_symbols = [Symbol(ge.expression.symbol(relations)) for ge in self.agg.groupingExpressions]
+            self._grouping_symbols = []
+            for ge in self.agg.groupingExpressions:
+                try:
+                    symb = ge.expression.symbol(relations)
+                except ValueError as err: # Check if the expression has been aliased in the SELECT clause
+                    if isinstance(ge.expression, Column):
+                        expr = [
+                            ne.expression for ne in self.select.namedExpressions
+                            if ne.name and metadata.compare.identifier_match(ge.expression.name, ne.name)
+                        ]
+                        if len(expr) == 1:
+                            symb = expr[0].symbol(relations)
+                        else:
+                            raise err
+                    else:
+                        raise err
+                self._grouping_symbols.append(Symbol(symb))
+
 
         # get namedExpression symbols
         _symbols = []
@@ -536,7 +553,7 @@ class TableColumn(SqlExpr):
         return self.tablename + "." + self.colname
 
     def __eq__(self, other):
-        return self.tablename == other.tablename and self.colname == other.colname
+        return isinstance(self, type(other)) and self.tablename == other.tablename and self.colname == other.colname
 
     def __hash__(self):
         return hash((self.tablename, self.colname))

--- a/sql/snsql/_ast/expression.py
+++ b/sql/snsql/_ast/expression.py
@@ -85,13 +85,15 @@ class NamedExpression(SqlExpr):
     def column_name(self):
         if self.name is not None:
             return self.name
-        elif type(self.expression) is Column:
+        if type(self.expression) is Column:
             parts = self.expression.name.split(".")
-            return parts[0] if len(parts) == 1 else '_'.join(parts)
-        elif type(self.expression) is AllColumns:
-            return "???"
-        else:
-            return "???"
+            if len(parts) == 1:
+                return parts[0]
+            if self.expression.escaped():
+                parts = [p.replace('"', '').replace('[', '') for p in parts]
+                return f'"{parts[0]}_{parts[1]}"'
+            return f'{parts[0]}_{parts[1]}'
+        return "???"
 
     def type(self):
         return self.expression.type()

--- a/sql/snsql/_ast/expression.py
+++ b/sql/snsql/_ast/expression.py
@@ -87,7 +87,7 @@ class NamedExpression(SqlExpr):
             return self.name
         elif type(self.expression) is Column:
             parts = self.expression.name.split(".")
-            return parts[0] if len(parts) == 1 else parts[1]
+            return parts[0] if len(parts) == 1 else '_'.join(parts)
         elif type(self.expression) is AllColumns:
             return "???"
         else:

--- a/sql/snsql/_ast/tokens.py
+++ b/sql/snsql/_ast/tokens.py
@@ -435,7 +435,13 @@ class Column(SqlExpr):
         return self.name
 
     def symbol(self, relations):
-        sym_exprs = [r.symbol(self) for r in relations if r.alias_match(self.name)]
+        sym_exprs = []
+        for r in relations:
+            if r.alias_match(self.name):
+                try:
+                    sym_exprs.append(r.symbol(self))
+                except ValueError:
+                    continue
         if len(sym_exprs) == 0:
             raise ValueError("Column cannot be found " + str(self))
         elif len(sym_exprs) > 1:

--- a/sql/tests/ast/test_load_symbols.py
+++ b/sql/tests/ast/test_load_symbols.py
@@ -41,3 +41,11 @@ class TestLoadSymbols:
         q = QueryParser(metadata).query(query)
         assert(q._named_symbols['temp'].expression.tablename == 'features')
         assert(q._named_symbols['sales'].expression.xpath_first('//TableColumn').tablename == 'sales')
+
+    def test_same_colname(self):
+        query = 'SELECT sales."Store", features."Store" FROM sales, features'
+        q = QueryParser(metadata).query(query)
+        assert(q._named_symbols['"sales_Store"'].expression.tablename == 'sales')
+        assert(q._named_symbols['"sales_Store"'].expression.colname == 'Store')
+        assert(q._named_symbols['"features_Store"'].expression.tablename == 'features')
+        assert(q._named_symbols['"features_Store"'].expression.colname == 'Store')


### PR DESCRIPTION
Fix load_symbols in queries when 
- the GROUP BY clause uses aliases from the SELECT clause 
e.g.: `SELECT "IsHoliday" As col, SUM(features."Store") FROM features GROUP BY col;` or `SELECT "IsHoliday" As "Col", SUM(features."Store") FROM features GROUP BY "Col";`
- they is more than one table. e.g.: `SELECT "Temperature", AVG("Weekly_Sales") FROM features, sales;`