### PR TITLE
Implement conditional sampling

### DIFF
--- a/synth/docs/source/index.rst
+++ b/synth/docs/source/index.rst
@@ -12,7 +12,7 @@ Getting Started
 
 Create a synthesizer with the ``Synthesizer.create()`` method, passing in the name of the sythesizer you want to create, along with a privacy budget and any synthesizer-specific hyperparameters.  To see a list of available synthesizers, use the ``Synthesizer.list_synthesizers()`` method or read the `Synthesizer Reference <synthesizers/index.html>`_.
 
-Each synthesizer has a ``fit()`` method that fits the synthesizer to a private data set, and a ``sample()`` method that generates synthetic data from the fitted synthesizer.  Each synthesizer also has a ``fit_sample()`` helper method that combines the ``fit()`` and ``sample()`` methods into a single call.
+Each synthesizer has a ``fit()`` method that fits the synthesizer to a private data set, and a ``sample()`` method that generates synthetic data from the fitted synthesizer.  Each synthesizer also has a ``fit_sample()`` helper method that combines the ``fit()`` and ``sample()`` methods into a single call. By using the ``sample_conditional()`` method one can generate samples that satisfy certain conditions. It performs rejection sampling and can enable analytics without prior retention of the synthetic data.
 
 .. code-block:: python
 
@@ -25,6 +25,9 @@ Each synthesizer has a ``fit()`` method that fits the synthesizer to a private d
   synth = Synthesizer.create('mwem', epsilon=1.0)
   sample = synth.fit_sample(pums)
   print(sample)
+
+  sample_conditional = synth.sample_conditional(100, "age < 50 AND income > 1000")
+  print(sample_conditional)
 
 Preprocessing Privacy Budget
 ----------------------------

--- a/synth/tests/test_sample_conditional.py
+++ b/synth/tests/test_sample_conditional.py
@@ -1,0 +1,108 @@
+import os
+import subprocess
+
+import numpy as np
+import pandas as pd
+import pytest
+from snsynth import Synthesizer
+
+git_root_dir = (
+    subprocess.check_output("git rev-parse --show-toplevel".split(" "))
+    .decode("utf-8")
+    .strip()
+)
+csv_path = os.path.join(git_root_dir, os.path.join("datasets", "PUMS.csv"))
+narrrow_columns = ["income", "married"]
+narrow_df = pd.read_csv(csv_path, index_col=None, usecols=narrrow_columns)
+
+
+class TestSampleConditional:
+    def test_n_row_invalid(self):
+        dummy_synth = Synthesizer()
+        for n_row in [-np.inf, -1, 0, 0.9]:
+            with pytest.raises(ValueError, match="n_rows"):
+                dummy_synth.sample_conditional(n_row, "dummy condition")
+
+    def test_max_tries_invalid(self):
+        dummy_synth = Synthesizer()
+        for max_tries in [-np.inf, -1, 0, 0.9]:
+            with pytest.raises(ValueError, match="max_tries"):
+                dummy_synth.sample_conditional(
+                    1, "dummy condition", max_tries=max_tries
+                )
+
+    def test_condition_unparsable(self):
+        dummy_synth = Synthesizer()
+        for condition in ["dummy condition", "age % 20", "WHERE age < 20"]:
+            with pytest.raises(ValueError, match="parse.*?condition"):
+                dummy_synth.sample_conditional(1, condition)
+
+    def test_condition_invalid_column_name(self):
+        dummy_synth = Synthesizer()
+
+        # define small test data set
+        columns = ["married"]
+        data = [1, 0]
+        invalid_condition = "age > 50"
+
+        # test with DataFrame
+        dummy_synth.sample = lambda _: pd.DataFrame(data=data, columns=columns)
+        with pytest.raises(ValueError, match="evaluate.*?condition"):
+            dummy_synth.sample_conditional(1, invalid_condition)
+
+        # test with list of tuples
+        dummy_synth.sample = lambda _: data
+        with pytest.raises(ValueError, match="evaluate.*?condition"):
+            dummy_synth.sample_conditional(1, invalid_condition, column_names=columns)
+
+    def test_condition_no_column_names(self):
+        dummy_synth = Synthesizer()
+        dummy_synth.sample = lambda _: [55]
+        with pytest.raises(ValueError, match="provide.*?column_names"):
+            dummy_synth.sample_conditional(1, "age > 50")
+
+    def test_max_tries_exceeded(self):
+        dummy_synth = Synthesizer()
+        dummy_synth.sample = lambda _: [1]
+
+        samples = dummy_synth.sample_conditional(
+            1, "married = 0", max_tries=5, column_names=["married"]
+        )
+        assert len(samples) == 0
+
+    def test_with_data_frame(self):
+        dummy_synth = Synthesizer()
+        dummy_synth.sample = lambda _: narrow_df
+        samples = dummy_synth.sample_conditional(10, "married = 0 AND income < 1000")
+
+        assert len(samples) == 10
+        assert isinstance(samples, pd.DataFrame)
+        assert samples.dtypes.equals(narrow_df.dtypes)
+        assert samples["income"].max() < 1000
+        assert samples["married"].max() == 0
+
+    def test_with_ndarray(self):
+        dummy_synth = Synthesizer()
+        dummy_synth.sample = lambda _: narrow_df.to_numpy()
+        samples = dummy_synth.sample_conditional(
+            10, "married = 0 AND income < 1000", column_names=narrrow_columns
+        )
+
+        assert len(samples) == 10
+        assert isinstance(samples, np.ndarray)
+        assert samples[0].max() < 1000
+        assert samples[1].max() == 0
+
+    def test_with_tuples(self):
+        dummy_synth = Synthesizer()
+        dummy_synth.sample = lambda _: list(narrow_df.itertuples(index=False))
+        samples = dummy_synth.sample_conditional(
+            10, "married = 0 AND income < 1000", column_names=narrrow_columns
+        )
+
+        assert len(samples) == 10
+        assert isinstance(samples, list)
+        income_max = max(s[0] for s in samples)
+        assert income_max < 1000
+        married_max = max(s[1] for s in samples)
+        assert married_max == 0


### PR DESCRIPTION
In this PR I implemented conditional sampling functionality as discussed in #496.

I also added a small example in the "Getting Gtarted" of the synthesizers documentation.

### Implementation details
I decided to implement the `sample_conditional()` method on the `Synthesizer` base class. This reduces overhead and simplifies the testing process. Not even a valid `Synthesizer` is needed because I mocked (or, more precisely: monkey patched) the `sample()` method. The tests achieve 100% code and branch coverage.


The method can handle pd.DataFrame, np.ndarray and list of tuples. Internally, it uses a `valid_rate` to calculate the number of samples in a batch, which can significantly reduce unnecessary sampling if fixed-size batches are sampled. 