### PR TITLE
Implement anonymization transformer

### DIFF
--- a/synth/pyproject.toml
+++ b/synth/pyproject.toml
@@ -15,6 +15,7 @@ opendp = "^0.6.0"
 opacus = "^0.14.0"
 pac-synth = "^0.0.6"
 smartnoise-sql = "^0.2.6"
+Faker = "^15.0.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/synth/setup.py
+++ b/synth/setup.py
@@ -18,7 +18,8 @@ install_requires = \
 ['opacus>=0.14.0,<0.15.0',
  'opendp>=0.6.0,<0.7.0',
  'pac-synth>=0.0.6,<0.0.7',
- 'smartnoise-sql>=0.2.6,<0.3.0']
+ 'smartnoise-sql>=0.2.6,<0.3.0',
+ 'Faker>=15.0.0']
 
 setup_kwargs = {
     'name': 'smartnoise-synth',

--- a/synth/snsynth/transform/__init__.py
+++ b/synth/snsynth/transform/__init__.py
@@ -9,7 +9,7 @@ from .standard import StandardScaler
 from .clamp import ClampTransformer
 from .log import LogTransformer
 from .table import NoTransformer
-
+from .anonymization import AnonymizationTransformer
 __all__ = [
     "TableTransformer", 
     "OneHotEncoder", 
@@ -21,5 +21,6 @@ __all__ = [
     "StandardScaler",
     "LogTransformer",
     "ClampTransformer",
-    "NoTransformer"
+    "NoTransformer",
+    "AnonymizationTransformer"
     ]

--- a/synth/snsynth/transform/anonymization.py
+++ b/synth/snsynth/transform/anonymization.py
@@ -1,0 +1,118 @@
+from .base import ColumnTransformer
+from .definitions import ColumnType
+from faker import Faker
+
+
+class AnonymizationTransformer(ColumnTransformer):
+    """
+    Transformer that can be used to anonymize personally identifiable information (PII) or other values.
+    By default, the existing values are discarded during transformation and not used by a synthesizer.
+    During inverse transformation new values will be generated according to the specified ``fake``.
+
+    If ``fake_inbound`` is true, the new values will be injected during transformation and passed through on inverse.
+    This might be useful for e.g. operation in a ChainTransformer.
+
+    Beware that the provided ``fake`` is called once to verify that the provided (keyword) arguments are valid.
+
+    :param fake: Text reference to Faker method (e.g. 'email') or custom callable
+    :type fake: str or callable, required
+    :param args: Arguments for the method
+    :type args: args, optional
+    :param faker_setup: Dictionary with keyword arguments for Faker initialization e.g. {'locale': 'de_DE'}
+    :type faker_setup: dict, optional
+    :param fake_inbound: Defaults to False.
+    :type fake_inbound: bool, optional
+    :param kwargs: Keyword arguments for the method
+    :type kwargs: kwargs, optional
+    """
+
+    def __init__(self, fake, *args, faker_setup=None, fake_inbound=False, **kwargs):
+        self.fake_inbound = fake_inbound
+        super().__init__()
+
+        if isinstance(fake, str):  # assume this references a Faker builtin
+            fake = self._get_faker_builtin(fake, faker_setup, *args, **kwargs)
+
+        self.fake = fake
+        self.args = args
+        self.kwargs = kwargs
+
+        # verify that the provided arguments are valid
+        try:
+            self._generate_fake_data()
+        except TypeError as e:
+            raise ValueError(f"Provided arguments {args} and {kwargs} are invalid for `fake` {fake}") from e
+
+    def _get_faker_builtin(self, fake, faker_setup, *args, **kwargs):
+        """
+        Creates a Faker instance and verifies that the given method is available.
+
+        :param fake: Text reference to Faker method
+        :type fake: str, required
+        :param faker_setup: Dictionary with keyword arguments for initializing Faker e.g. {'locale': 'de_DE'}
+        :type faker_setup: dict, optional
+        :param args: Arguments for the method
+        :type args: args, optional
+        :param kwargs: Keyword arguments for the method
+        :type kwargs: kwargs, optional
+        :return: Actual Faker method
+        :rtype: callable
+        """
+        # initialize Faker with provided setup or default
+        if isinstance(faker_setup, dict):
+            try:
+                self.faker = Faker(**faker_setup)
+            except Exception as e:
+                raise ValueError(f"Provided `faker_setup` {faker_setup} is invalid") from e
+        else:
+            self.faker = Faker()
+
+        # verify that the provided fake is available
+        try:
+            fake_builtin = getattr(self.faker, fake)
+        except AttributeError as e:
+            raise ValueError(f"Provided `fake` {fake} is not available in Faker") from e
+
+        return fake_builtin
+
+    @property
+    def output_type(self):
+        return ColumnType.CONTINUOUS
+
+    @property
+    def cardinality(self):
+        return [None]
+
+    def _fit(self, _):
+        pass
+
+    def _clear_fit(self):
+        self._fit_complete = True
+        self.output_width = 1 if self.fake_inbound else 0
+
+    def _generate_fake_data(self):
+        return self.fake(*self.args, **self.kwargs)
+
+    def _transform(self, _):
+        if self.fake_inbound:
+            return self._generate_fake_data()
+        else:
+            return None
+
+    def _inverse_transform(self, val):
+        if self.fake_inbound:
+            return val
+        else:
+            return self._generate_fake_data()
+
+    def transform(self, data, idx=None):
+        if idx is None:
+            return [self._transform(val) for val in data]
+        else:
+            return [row[:idx] + row[idx + 1:] for row in data]
+
+    def inverse_transform(self, data, idx=None):
+        if idx is None:
+            return [self._inverse_transform(val) for val in data]
+        else:
+            return [row[:idx] + (self._inverse_transform(None),) + row[idx:] for row in data]

--- a/synth/snsynth/transform/anonymization.py
+++ b/synth/snsynth/transform/anonymization.py
@@ -41,7 +41,9 @@ class AnonymizationTransformer(ColumnTransformer):
         try:
             self._generate_fake_data()
         except TypeError as e:
-            raise ValueError(f"Provided arguments {args} and {kwargs} are invalid for `fake` {fake}") from e
+            raise ValueError(
+                f"Provided arguments {args} and {kwargs} are invalid for `fake` {fake}"
+            ) from e
 
     def _get_faker_builtin(self, fake, faker_setup, *args, **kwargs):
         """
@@ -63,7 +65,9 @@ class AnonymizationTransformer(ColumnTransformer):
             try:
                 self.faker = Faker(**faker_setup)
             except Exception as e:
-                raise ValueError(f"Provided `faker_setup` {faker_setup} is invalid") from e
+                raise ValueError(
+                    f"Provided `faker_setup` {faker_setup} is invalid"
+                ) from e
         else:
             self.faker = Faker()
 
@@ -109,10 +113,12 @@ class AnonymizationTransformer(ColumnTransformer):
         if idx is None:
             return [self._transform(val) for val in data]
         else:
-            return [row[:idx] + row[idx + 1:] for row in data]
+            return [row[:idx] + row[idx + 1 :] for row in data]
 
     def inverse_transform(self, data, idx=None):
         if idx is None:
             return [self._inverse_transform(val) for val in data]
         else:
-            return [row[:idx] + (self._inverse_transform(None),) + row[idx:] for row in data]
+            return [
+                row[:idx] + (self._inverse_transform(None),) + row[idx:] for row in data
+            ]

--- a/synth/snsynth/transform/table.py
+++ b/synth/snsynth/transform/table.py
@@ -5,6 +5,8 @@ import warnings
 from snsql.sql.odometer import OdometerHeterogeneous
 from snsql.sql.privacy import Privacy
 from sqlalchemy import null
+
+from .anonymization import AnonymizationTransformer
 from snsynth.transform.type_map import TypeMap
 
 class TableTransformer:
@@ -109,7 +111,9 @@ class TableTransformer:
     def _transform(self, row):
         out_row = []
         for v, t in zip(row, self.transformers):
-            if t.output_width == 1:
+            if isinstance(t, AnonymizationTransformer) and not t.fake_inbound:
+                pass  # don't include any values if we wish to anonymize with inverse transformation
+            elif t.output_width == 1:
                 out_row.append(t._transform(v))
             else:
                 for out_v in t._transform(v):

--- a/synth/tests/transform/test_anonymization.py
+++ b/synth/tests/transform/test_anonymization.py
@@ -11,7 +11,9 @@ git_root_dir = (
     .strip()
 )
 csv_path = os.path.join(git_root_dir, os.path.join("datasets", "PUMS.csv"))
-narrow_df = pd.read_csv(csv_path, index_col=None, usecols=["age", "income", "married"], nrows=20)
+narrow_df = pd.read_csv(
+    csv_path, index_col=None, usecols=["age", "income", "married"], nrows=20
+)
 
 str_list = ["a", "b", "c"]
 count = -1
@@ -32,7 +34,7 @@ class TestAnonymization:
         assert anon.fit_complete
         transformed = anon.transform(str_list)
         inversed = anon.inverse_transform(transformed)
-        assert (len(inversed) == len(str_list))
+        assert len(inversed) == len(str_list)
         assert all(email.split("@")[1] == domain for email in inversed)
 
     def test_faker_builtin_with_invalid_arguments(self):
@@ -44,16 +46,20 @@ class TestAnonymization:
             AnonymizationTransformer("obviously_invalid_builtin")
 
     def test_faker_with_setup(self):
-        anon = AnonymizationTransformer("current_country", faker_setup={"locale": "de_DE"})
+        anon = AnonymizationTransformer(
+            "current_country", faker_setup={"locale": "de_DE"}
+        )
         assert anon.fit_complete
         transformed = anon.transform(str_list)
         inversed = anon.inverse_transform(transformed)
-        assert (len(inversed) == len(str_list))
+        assert len(inversed) == len(str_list)
         assert all(country == "Germany" for country in inversed)
 
     def test_faker_with_invalid_setup(self):
         with pytest.raises(ValueError, match="faker_setup.*?invalid"):
-            AnonymizationTransformer("email", faker_setup={"providers": "obviously_invalid_provider"})
+            AnonymizationTransformer(
+                "email", faker_setup={"providers": "obviously_invalid_provider"}
+            )
 
     # tests with caller-provided functions
     def test_with_function(self):
@@ -63,33 +69,33 @@ class TestAnonymization:
         assert anon.fit_complete
         transformed = anon.transform(str_list)
         inversed = anon.inverse_transform(transformed)
-        assert (len(inversed) == len(str_list))
-        assert (sum(inversed) == counter_sum)
+        assert len(inversed) == len(str_list)
+        assert sum(inversed) == counter_sum
 
     def test_with_parametrized_lambda(self):
         anon = AnonymizationTransformer(lambda x: x + 1, 1)
         assert anon.fit_complete
         transformed = anon.transform(str_list)
         inversed = anon.inverse_transform(transformed)
-        assert (len(inversed) == len(str_list))
+        assert len(inversed) == len(str_list)
         assert all(n == 2 for n in inversed)
 
     def _test_with_dummy_lambda(self, original, idx):
         anon = AnonymizationTransformer(lambda: "dummy")
         assert anon.fit_complete
         transformed = anon.transform(original, idx=idx)
-        assert (len(transformed) == len(original))
-        assert (all([len(a) == len(b) - 1 for a, b in zip(transformed, original)]))
+        assert len(transformed) == len(original)
+        assert all([len(a) == len(b) - 1 for a, b in zip(transformed, original)])
         inversed = anon.inverse_transform(transformed, idx=idx)
-        assert (len(inversed) == len(original))
+        assert len(inversed) == len(original)
         for row_inversed, row_original in zip(inversed, original):
             n_original = len(row_original)
-            assert (len(row_inversed) == n_original)
+            assert len(row_inversed) == n_original
             for i in range(n_original):
                 if i == idx:
-                    assert (row_inversed[i] == "dummy")
+                    assert row_inversed[i] == "dummy"
                 else:
-                    assert (row_inversed[i] == row_original[i])
+                    assert row_inversed[i] == row_original[i]
 
     def test_one_column_with_idx(self):
         pums_tuples = [t[2:] for t in narrow_df.itertuples(index=False)]
@@ -113,8 +119,8 @@ class TestAnonymization:
         anon = AnonymizationTransformer(lambda: "dummy", fake_inbound=True)
         assert anon.fit_complete
         transformed = anon.transform(str_list)
-        assert (len(transformed) == len(str_list))
+        assert len(transformed) == len(str_list)
         assert all(t == "dummy" for t in transformed)
         inversed = anon.inverse_transform(transformed)
-        assert (len(inversed) == len(str_list))
+        assert len(inversed) == len(str_list)
         assert all(t == "dummy" for t in inversed)

--- a/synth/tests/transform/test_anonymization.py
+++ b/synth/tests/transform/test_anonymization.py
@@ -1,0 +1,120 @@
+import os
+import subprocess
+
+import pandas as pd
+import pytest
+from snsynth.transform.anonymization import AnonymizationTransformer
+
+git_root_dir = (
+    subprocess.check_output("git rev-parse --show-toplevel".split(" "))
+    .decode("utf-8")
+    .strip()
+)
+csv_path = os.path.join(git_root_dir, os.path.join("datasets", "PUMS.csv"))
+narrow_df = pd.read_csv(csv_path, index_col=None, usecols=["age", "income", "married"], nrows=20)
+
+str_list = ["a", "b", "c"]
+count = -1
+
+
+def dummy_counter():
+    global count
+    count += 1
+    return count
+
+
+class TestAnonymization:
+    # tests with Faker library
+    def test_faker_builtin_with_kwargs(self):
+        domain = "opendp.org"
+
+        anon = AnonymizationTransformer("email", domain=domain)
+        assert anon.fit_complete
+        transformed = anon.transform(str_list)
+        inversed = anon.inverse_transform(transformed)
+        assert (len(inversed) == len(str_list))
+        assert all(email.split("@")[1] == domain for email in inversed)
+
+    def test_faker_builtin_with_invalid_arguments(self):
+        with pytest.raises(ValueError, match="arguments.*?invalid"):
+            AnonymizationTransformer("email", obviously_invalid_kwarg="")
+
+    def test_faker_invalid_builtin(self):
+        with pytest.raises(ValueError, match="fake.*?not available"):
+            AnonymizationTransformer("obviously_invalid_builtin")
+
+    def test_faker_with_setup(self):
+        anon = AnonymizationTransformer("current_country", faker_setup={"locale": "de_DE"})
+        assert anon.fit_complete
+        transformed = anon.transform(str_list)
+        inversed = anon.inverse_transform(transformed)
+        assert (len(inversed) == len(str_list))
+        assert all(country == "Germany" for country in inversed)
+
+    def test_faker_with_invalid_setup(self):
+        with pytest.raises(ValueError, match="faker_setup.*?invalid"):
+            AnonymizationTransformer("email", faker_setup={"providers": "obviously_invalid_provider"})
+
+    # tests with caller-provided functions
+    def test_with_function(self):
+        counter_sum = sum(range(1, len(str_list) + 1))
+
+        anon = AnonymizationTransformer(dummy_counter)
+        assert anon.fit_complete
+        transformed = anon.transform(str_list)
+        inversed = anon.inverse_transform(transformed)
+        assert (len(inversed) == len(str_list))
+        assert (sum(inversed) == counter_sum)
+
+    def test_with_parametrized_lambda(self):
+        anon = AnonymizationTransformer(lambda x: x + 1, 1)
+        assert anon.fit_complete
+        transformed = anon.transform(str_list)
+        inversed = anon.inverse_transform(transformed)
+        assert (len(inversed) == len(str_list))
+        assert all(n == 2 for n in inversed)
+
+    def _test_with_dummy_lambda(self, original, idx):
+        anon = AnonymizationTransformer(lambda: "dummy")
+        assert anon.fit_complete
+        transformed = anon.transform(original, idx=idx)
+        assert (len(transformed) == len(original))
+        assert (all([len(a) == len(b) - 1 for a, b in zip(transformed, original)]))
+        inversed = anon.inverse_transform(transformed, idx=idx)
+        assert (len(inversed) == len(original))
+        for row_inversed, row_original in zip(inversed, original):
+            n_original = len(row_original)
+            assert (len(row_inversed) == n_original)
+            for i in range(n_original):
+                if i == idx:
+                    assert (row_inversed[i] == "dummy")
+                else:
+                    assert (row_inversed[i] == row_original[i])
+
+    def test_one_column_with_idx(self):
+        pums_tuples = [t[2:] for t in narrow_df.itertuples(index=False)]
+
+        self._test_with_dummy_lambda(pums_tuples, 0)
+
+    def test_two_columns_with_idx(self):
+        pums_tuples = [t[1:] for t in narrow_df.itertuples(index=False)]
+
+        self._test_with_dummy_lambda(pums_tuples, 0)
+        self._test_with_dummy_lambda(pums_tuples, 1)
+
+    def test_three_columns_with_idx(self):
+        pums_tuples = [t for t in narrow_df.itertuples(index=False)]
+
+        self._test_with_dummy_lambda(pums_tuples, 0)
+        self._test_with_dummy_lambda(pums_tuples, 1)
+        self._test_with_dummy_lambda(pums_tuples, 2)
+
+    def test_fake_inbound(self):
+        anon = AnonymizationTransformer(lambda: "dummy", fake_inbound=True)
+        assert anon.fit_complete
+        transformed = anon.transform(str_list)
+        assert (len(transformed) == len(str_list))
+        assert all(t == "dummy" for t in transformed)
+        inversed = anon.inverse_transform(transformed)
+        assert (len(inversed) == len(str_list))
+        assert all(t == "dummy" for t in inversed)


### PR DESCRIPTION
In this PR I implemented an `AnonymizationTransformer` as discussed in #505.

I also added a dependency for the `Faker` library and documented an example in the transformers documentation.

### Implementation details
As suggested, the existing values are discarded during transformation and new ones will be generated during `_inverse_transform()`.

The transformer supports `Faker`. Even the configuration of e.g. `locale` and custom providers can be done. Apart from these built-ins, a custom callable can be provided.

If someone wants to use the fakes for training of a synthesizer, the optional argument `fake_inbound=True` can be provided. Then the new values will be injected during transformation and are passed through on inverse. This also enables usage in a `ChainTransformer`.

### Proposal
We could raise an error if an `AnonymizationTransformer` is given in a chain without having `fake_inbound` set to true. I would refrain from setting the argument implicitly or discarding `None` values in general, and instead make the user aware. Otherwise, one could falsely assume that the synthesizer is not trained with fake values, when he actually is.

Even though the tests achieve 100% code and branch coverage, I think it would be a good idea to add tests in `TestTableTransform`. 

