### PR TITLE
Fix OneHotEncoder implementation

### DIFF
--- a/synth/snsynth/transform/onehot.py
+++ b/synth/snsynth/transform/onehot.py
@@ -27,6 +27,11 @@ class OneHotEncoder(ColumnTransformer):
     def _transform(self, val):
         if self.max < 0 or not self._fit_complete:
             raise ValueError("OneHotEncoder has not been fit yet.")
+        elif val < 0 or val > self.max:
+            raise ValueError(
+                f"Provided integer-label {val} is invalid."
+                " Please ensure that all inputs are 0-based and provided during data fit."
+            )
         elif self.max == 0:
             return 1
 

--- a/synth/snsynth/transform/onehot.py
+++ b/synth/snsynth/transform/onehot.py
@@ -27,6 +27,9 @@ class OneHotEncoder(ColumnTransformer):
     def _transform(self, val):
         if self.max < 0 or not self._fit_complete:
             raise ValueError("OneHotEncoder has not been fit yet.")
+        elif self.max == 0:
+            return 1
+
         bits = [0] * (self.max + 1)
         bits[val] = 1
         return tuple(bits)

--- a/synth/tests/transform/test_onehot.py
+++ b/synth/tests/transform/test_onehot.py
@@ -1,5 +1,5 @@
+import pytest
 import seaborn as sns
-import numpy as np
 from snsynth.transform.label import LabelTransformer
 from snsynth.transform.onehot import OneHotEncoder
 
@@ -40,6 +40,14 @@ class TestOneHot:
         data_decoded = ohe.inverse_transform(data_encoded)
         assert data_decoded == data
 
+    def test_invalid_val(self):
+        ohe = OneHotEncoder()
+        ohe.fit([0])
+        for data in [[-1], [-0.1], [0.1], [1]]:
+            with pytest.raises(ValueError, match="label.*?invalid"):
+                ohe.transform(data)
 
-
-
+    def test_not_fit(self):
+        ohe = OneHotEncoder()
+        with pytest.raises(ValueError, match="not.*?fit"):
+            ohe.transform([0])

--- a/synth/tests/transform/test_onehot.py
+++ b/synth/tests/transform/test_onehot.py
@@ -30,7 +30,15 @@ class TestOneHot:
         assert(ohe.output_width == 3)
         cat_decoded = ohe.inverse_transform(cat_encoded)
         assert(all([a == b for a, b in zip(categories, cat_decoded)]))
-
+    def test_onehot_single_val(self):
+        ohe = OneHotEncoder()
+        data = [0]
+        ohe.fit(data)
+        assert(ohe.output_width == 1)
+        data_encoded = ohe.transform(data)
+        assert data_encoded[0] == 1
+        data_decoded = ohe.inverse_transform(data_encoded)
+        assert data_decoded == data
 
 
 


### PR DESCRIPTION
This PR adresses the error encountered in #509.

### Implementation details
I implemented a simple test for the described problem. Then I fixed the current `OneHotEncoder` implementation by returning the value directly instead of a tuple.