### PR TITLE
Makes postgres engine commit every time a query is made

### DIFF
--- a/sql/snsql/sql/reader/postgres.py
+++ b/sql/snsql/sql/reader/postgres.py
@@ -42,14 +42,19 @@ class PostgresReader(SqlReader):
         cnxn = self.conn
         if cnxn is None:
             cnxn = self.api.connect(self.connection_string)
-        cursor = cnxn.cursor()
-        cursor.execute(str(query))
-        if cursor.description is None:
-            return []
-        else:
-            col_names = [tuple(desc[0] for desc in cursor.description)]
-            rows = [row for row in cursor]
-            return col_names + rows
+        try:
+            cursor = cnxn.cursor()
+            cursor.execute(str(query))
+            cnxn.commit()
+            if cursor.description is None:
+                return []
+            else:
+                col_names = [tuple(desc[0] for desc in cursor.description)]
+                rows = [row for row in cursor]
+                return col_names + rows
+        except Exception as e:
+            cnxn.commit()
+            raise e
 
     def _update_connection_string(self):
         self.connection_string = "user='{0}' host='{1}'".format(self.user, self.host)

--- a/sql/snsql/sql/reader/postgres.py
+++ b/sql/snsql/sql/reader/postgres.py
@@ -53,7 +53,7 @@ class PostgresReader(SqlReader):
                 rows = [row for row in cursor]
                 return col_names + rows
         except Exception as e:
-            cnxn.commit()
+            cnxn.rollback()
             raise e
 
     def _update_connection_string(self):


### PR DESCRIPTION
Since we only have read queries, not writes, it's safe to autocommit per transaction, and this prevents weird engine errors where one failed txn means all future txns with that PrivateReader will fail.