### PR TITLE
Implement preprocessor constraints

### DIFF
--- a/synth/snsynth/base.py
+++ b/synth/snsynth/base.py
@@ -146,16 +146,17 @@ class Synthesizer(SDGYMBaseSynthesizer):
         """
         return list(synth_map.keys())
     def _get_train_data(self, data, *ignore, style, transformer, categorical_columns, ordinal_columns, continuous_columns, nullable, preprocessor_eps):
-        if transformer is None:
+        if transformer is None or isinstance(transformer, dict):
             self._transformer = TableTransformer.create(data, style=style,
                 categorical_columns=categorical_columns,
                 continuous_columns=continuous_columns,
                 ordinal_columns=ordinal_columns,
-                nullable=nullable,)
+                nullable=nullable,
+                constraints=transformer)
         elif isinstance(transformer, TableTransformer):
             self._transformer = transformer
         else:
-            raise ValueError("transformer must be a TableTransformer object or None.  See the updated documentation.")
+            raise ValueError("transformer must be a TableTransformer object, a dictionary or None.")
         if not self._transformer.fit_complete:
             if self._transformer.needs_epsilon and (preprocessor_eps is None or preprocessor_eps == 0.0):
                 raise ValueError("Transformer needs some epsilon to infer bounds.  If you know the bounds, pass them in to save budget.  Otherwise, set preprocessor_eps to a value > 0.0 and less than the training epsilon.  Preprocessing budget will be subtracted from training budget.")

--- a/synth/snsynth/base.py
+++ b/synth/snsynth/base.py
@@ -22,24 +22,26 @@ class SDGYMBaseSynthesizer:
 
         :param data: The private data used to fit the synthesizer.
         :type data: pd.DataFrame, np.ndarray, or list of tuples
-        :param transformer: The transformer to use to preprocess the data.  If no transformer 
-            is provided, the synthesizer will attempt to choose a transformer suitable for that 
-            synthesizer.  To prevent the synthesizer from choosing a transformer, pass in
-            snsynth.transform.NoTransformer().
-        :type transformer: snsynth.transform.TableTransformer, optional
+        :param transformer: The transformer to use to preprocess the data.
+            If no transformer is provided, the synthesizer will attempt to choose a transformer suitable for that synthesizer.
+            To prevent the synthesizer from choosing a transformer, pass in snsynth.transform.NoTransformer().
+            The inferred preprocessor can be constrained for certain columns by providing a dictionary.
+            Read the ``TableTransformer.create()`` method documentation for details about the constraints.
+        :type transformer: snsynth.transform.TableTransformer or dictionary, optional
         :param categorical_columns: List of column names or indixes to be treated as categorical columns, used as hints when no transformer is provided.
         :type categorical_columns: list[], optional
         :param ordinal_columns: List of column names or indices to be treated as ordinal columns, used as hints when no transformer is provided.
         :type ordinal_columns: list[], optional
-        :param ordinal_columns: List of column names or indices to be treated as ordinal columns, used as hints when no transformer is provided.
-        :type ordinal_columns: list[], optional
+        :param continuous_columns: List of column names or indices to be treated as continuous columns, used as hints when no transformer is provided.
+        :type continuous_columns: list[], optional
         :param preprocessor_eps: The epsilon value to use when preprocessing the data.  This epsilon budget is subtracted from the
             budget supplied when creating the synthesizer, but is only used if the preprocessing requires
             privacy budget, for example if bounds need to be inferred for continuous columns.  This value defaults to
             0.0, and the synthesizer will raise an error if the budget is not sufficient to preprocess the data.
         :type preprocessor_eps: float, optional
-        :param nullable: Whether or not to allow null values in the data.  This is only used if no transformer is provided,
-            and is used as a hint when inferring transformers.
+        :param nullable: Whether to allow null values in the data. This is only used if no transformer is provided,
+            and is used as a hint when inferring transformers. Defaults to False.
+        :type nullable: bool, optional
         """
         raise NotImplementedError
 
@@ -71,24 +73,26 @@ class SDGYMBaseSynthesizer:
 
         :param data: The private data used to fit the synthesizer.
         :type data: pd.DataFrame, np.ndarray, or list of tuples
-        :param transformer: The transformer to use to preprocess the data.  If no transformer 
-            is provided, the synthesizer will attempt to choose a transformer suitable for that 
-            synthesizer.  To prevent the synthesizer from choosing a transformer, pass in
-            snsynth.transform.NoTransformer().
-        :type transformer: snsynth.transform.TableTransformer, optional
+        :param transformer: The transformer to use to preprocess the data.
+            If no transformer is provided, the synthesizer will attempt to choose a transformer suitable for that synthesizer.
+            To prevent the synthesizer from choosing a transformer, pass in snsynth.transform.NoTransformer().
+            The inferred preprocessor can be constrained for certain columns by providing a dictionary.
+            Read the ``TableTransformer.create()`` method documentation for details about the constraints.
+        :type transformer: snsynth.transform.TableTransformer or dict, optional
         :param categorical_columns: List of column names or indixes to be treated as categorical columns, used as hints when no transformer is provided.
         :type categorical_columns: list[], optional
         :param ordinal_columns: List of column names or indices to be treated as ordinal columns, used as hints when no transformer is provided.
         :type ordinal_columns: list[], optional
-        :param ordinal_columns: List of column names or indices to be treated as ordinal columns, used as hints when no transformer is provided.
-        :type ordinal_columns: list[], optional
+        :param continuous_columns: List of column names or indices to be treated as continuous columns, used as hints when no transformer is provided.
+        :type continuous_columns: list[], optional
         :param preprocessor_eps: The epsilon value to use when preprocessing the data.  This epsilon budget is subtracted from the
             budget supplied when creating the synthesizer, but is only used if the preprocessing requires
             privacy budget, for example if bounds need to be inferred for continuous columns.  This value defaults to
             0.0, and the synthesizer will raise an error if the budget is not sufficient to preprocess the data.
         :type preprocessor_eps: float, optional
-        :param nullable: Whether or not to allow null values in the data.  This is only used if no transformer is provided,
-            and is used as a hint when inferring transformers.
+        :param nullable: Whether to allow null values in the data. This is only used if no transformer is provided,
+            and is used as a hint when inferring transformers. Defaults to False.
+        :type nullable: bool, optional
         """
         self.fit(
             data, 

--- a/synth/snsynth/pytorch/nn/ctgan/ctgan.py
+++ b/synth/snsynth/pytorch/nn/ctgan/ctgan.py
@@ -207,8 +207,6 @@ class CTGANSynthesizer(BaseSynthesizer):
                 transformed = self._gumbel_softmax(data[:, st:ed], tau=0.2)
                 data_t.append(transformed)
                 st = ed
-            else:
-                assert 0
 
         return torch.cat(data_t, dim=1)
 

--- a/synth/snsynth/transform/__init__.py
+++ b/synth/snsynth/transform/__init__.py
@@ -10,6 +10,7 @@ from .clamp import ClampTransformer
 from .log import LogTransformer
 from .table import NoTransformer
 from .anonymization import AnonymizationTransformer
+from .drop import DropTransformer
 __all__ = [
     "TableTransformer", 
     "OneHotEncoder", 
@@ -22,5 +23,6 @@ __all__ = [
     "LogTransformer",
     "ClampTransformer",
     "NoTransformer",
-    "AnonymizationTransformer"
+    "AnonymizationTransformer",
+    "DropTransformer"
     ]

--- a/synth/snsynth/transform/drop.py
+++ b/synth/snsynth/transform/drop.py
@@ -1,0 +1,41 @@
+from .base import ColumnTransformer
+from .definitions import ColumnType
+
+
+class DropTransformer(ColumnTransformer):
+    """
+    Transformer that ignores a column completely. All values will be dropped during transformation.
+    Inverse transformation is a no-op.
+    """
+    def __init__(self):
+        super().__init__()
+
+    @property
+    def output_type(self):
+        return ColumnType.UNBOUNDED
+
+    @property
+    def cardinality(self):
+        return [None]
+
+    def _fit(self, _):
+        pass
+
+    def _clear_fit(self):
+        self._fit_complete = True
+        self.output_width = 0
+
+    def _transform(self, _):
+        pass
+
+    def _inverse_transform(self, _):
+        pass
+
+    def transform(self, data, idx=None):
+        if idx is None:
+            return [None for _ in data]
+        else:
+            return [row[:idx] + row[idx + 1 :] for row in data]
+
+    def inverse_transform(self, data, idx=None):
+        return data

--- a/synth/snsynth/transform/table.py
+++ b/synth/snsynth/transform/table.py
@@ -44,6 +44,8 @@ class TableTransformer:
         """Returns the cardinality of each output column.  Returns None for continuous columns."""
         cards = []
         for t in self.transformers:
+            if isinstance(t, DropTransformer) or isinstance(t, AnonymizationTransformer):
+                continue # don't include cardinality for the unbounded transformers
             for c in t.cardinality:
                 cards.append(c)
         return cards

--- a/synth/snsynth/transform/table.py
+++ b/synth/snsynth/transform/table.py
@@ -185,8 +185,34 @@ class TableTransformer:
         column_names = list(range(len(data[0])))
         return cls.from_column_names(column_names, style=style, nullable=nullable, categorical_columns=categorical_columns, ordinal_columns=ordinal_columns, continuous_columns=continuous_columns, special_types=special_types, constraints=constraints)
     @classmethod
-    def create(cls, data, style='gan', *ignore, nullable=False, categorical_columns=[], ordinal_columns=[], continuous_columns=[], special_types={}):
-        """Creates a transformer from data.
+    def create(cls, data, style='gan', *ignore, nullable=False, categorical_columns=[], ordinal_columns=[], continuous_columns=[], special_types={}, constraints=None):
+        """
+        Creates a transformer for the given data. Infers all columns if the provided lists are empty.
+        Columns that are referenced in a constraint will be excluded from the inference.
+
+        :param data: The private data to construct a transformer for.
+        :type data: pd.DataFrame, np.ndarray, or list of tuples
+        :param style: The style influences the choice of ColumnTransformers. Can either be 'gan' or 'cube'.
+            Defaults to 'gan' which results in one-hot style.
+        :type style: string, optional
+        :param nullable: Whether to allow null values in the data. This is used as a hint when inferring transformers.
+            Defaults to False.
+        :type nullable: bool, optional
+        :param categorical_columns: List of column names or indixes to be treated as categorical columns, used as hint.
+        :type categorical_columns: list[], optional
+        :param ordinal_columns: List of column names or indices to be treated as ordinal columns, used as hint.
+        :type ordinal_columns: list[], optional
+        :param continuous_columns: List of column names or indices to be treated as continuous columns, used as hint.
+        :type continuous_columns: list[], optional
+        :param constraints: Dictionary that maps from column names or indixes to constraints.
+            There are multiple ways to specify a constraint.
+            It can be a ``ColumnTransformer`` object, type or class name.
+            Another possiblity is the string keyword 'drop' which enforces a ``DropTransformer``.
+            Also, a string alias for any of the lists like 'categorical' can be provided.
+            All other values e.g. a callable or Faker method will be passed into an ``AnonymizationTransformer``.
+        :type constraints: dict, optional
+        :returns: The transformer object
+        :rtype: TableTransformer
         """
         if categorical_columns is None:
             categorical_columns = []

--- a/synth/tests/transform/test_drop.py
+++ b/synth/tests/transform/test_drop.py
@@ -1,0 +1,35 @@
+from snsynth.transform.drop import DropTransformer
+
+
+class TestDrop:
+    def _test_drop_all_indices(self, data):
+        drop = DropTransformer()
+        assert drop.fit_complete
+        transformed = drop.transform(data)
+        assert len(transformed) == len(data)
+        assert all(v is None for v in transformed)
+        inversed = drop.inverse_transform(transformed)
+        assert len(inversed) == len(data)
+        assert all(v is None for v in inversed)
+
+    def test_list_of_values(self):
+        str_list = ["a", "b", "c"]
+
+        self._test_drop_all_indices(str_list)
+
+    def test_tuples(self):
+        tuples = [(0, "x"), (1, "x"), (2, "x")]
+
+        self._test_drop_all_indices(tuples)
+
+    def test_tuples_drop_single_index(self):
+        tuples = [(0, "x"), (1, "x"), (2, "x")]
+
+        drop = DropTransformer()
+        assert drop.fit_complete
+        transformed = drop.transform(tuples, idx=0)
+        assert len(transformed) == len(tuples)
+        assert all(v == "x" for v, in transformed)
+        inversed = drop.inverse_transform(transformed, idx=0)
+        assert len(inversed) == len(tuples)
+        assert all(v == "x" for v, in inversed)


### PR DESCRIPTION
In this PR I implemented the possibility to constrain the preprocessor according to #517.
Furthermore, I implemented a `DropTransformer` that enables a user to completely drop a column.

### Implementation details
I added the functionality on top of the legacy approach for SDGym. This means that a column can be referenced either in one of the three lists or as a constraint. I am in favor of maintaining the lists for compatibility reasons, at least until the next major release.

As proposed, a column referenced in the optional `constraints` dictionary is not inferred. There are multiple ways to specify a constraint, have a look at the `TableTransformer.create()` method documentation. A constraint might use privacy budget if e.g. a `MinMaxTransformer` is enforced without providing the bounds.

The `constraints` dictionary can be provided instead of a `TableTransformer` instance. This prevents a new parameter from being required. However, I have not touched the `special_types` dictionary yet. Maybe you can take care of that if you agree with the proposed approach?

Here is an example which showcases different usage scenarios:
```python
import pandas as pd
from snsynth import Synthesizer
from snsynth.transform import *

pums = pd.read_csv("PUMS.csv", index_col=None, usecols=["age", "income", "married"])

for synth_name in Synthesizer.list_synthesizers():
    print(f"synth: {synth_name}")

    # infer all columns except age
    synth = Synthesizer.create(synth_name, epsilon=1.0)
    synth.fit(pums, transformer={"age": "address"}, preprocessor_eps=0.5)
    print(synth.sample(10))

    # infer all columns except income
    synth = Synthesizer.create(synth_name, epsilon=1.0)
    synth.fit(pums, transformer={"income": AnonymizationTransformer(lambda: 123)}, preprocessor_eps=0.5)
    print(synth.sample(10))

    # don't infer any column type
    synth = Synthesizer.create(synth_name, epsilon=1.0)
    synth.fit(pums, transformer={"age": "ordinal", "income": "continuous", "married": "categorical"},
              preprocessor_eps=0.5)
    print(synth.sample(10))
```

### Proposal
A usage example in the data transformers documentation should be added.
At least some end-to-end test like in `TestFactory` would be good as well. I did not include the above example as a test because the runtime is quite long.