### PR TITLE
Bump python version to >=3.8 in pyproject.toml

### DIFF
--- a/sql/pyproject.toml
+++ b/sql/pyproject.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/opendp/smartnoise-sdk"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.7,<3.12"
+python = ">=3.8,<3.12"
 opendp = "^0.7.0"
 antlr4-python3-runtime = "4.9.3"
 PyYAML = "^6.0.1"


### PR DESCRIPTION
There was already a conflict with the pandas requirement, the constraint was unsatisfiable. Trying to run `poetry lock` errored out with this:

```
The current project's Python requirement (>=3.7,<3.12) is not compatible with some of the required packages Python requirement:
  - pandas requires Python >=3.9, so it will not be satisfied for Python >=3.7,<3.9
  - pandas requires Python >=3.8, so it will not be satisfied for Python >=3.7,<3.8
  - pandas requires Python >=3.8, so it will not be satisfied for Python >=3.7,<3.8
  - pandas requires Python >=3.8, so it will not be satisfied for Python >=3.7,<3.8
  - pandas requires Python >=3.9, so it will not be satisfied for Python >=3.7,<3.9

Because no versions of pandas match >2.0.1,<2.0.2 || >2.0.2,<2.0.3 || >2.0.3,<2.1.0 || >2.1.0,<2.1.1 || >2.1.1,<3.0.0
 and pandas (2.0.1) requires Python >=3.8, pandas is forbidden.
And because pandas (2.0.2) requires Python >=3.8, pandas is forbidden.
And because pandas (2.0.3) requires Python >=3.8
 and pandas (2.1.0) requires Python >=3.9, pandas is forbidden.
So, because pandas (2.1.1) requires Python >=3.9
 and smartnoise-sql depends on pandas (^2.0.1), version solving failed.
```