### PR TITLE
[Fix MWEM.py] Removed deprecated numpy .product() call

### DIFF
--- a/synth/snsynth/mwem.py
+++ b/synth/snsynth/mwem.py
@@ -1,4 +1,4 @@
-zimport math
+import math
 import random
 from typing import List
 import warnings


### PR DESCRIPTION
See the title, a simple change to one function to fix the MWEMSynthesiser :)
I make the change in my local .venv and everything works fine.
Hope you have a fantastic day <3