### PR TITLE
feature: Update mbi to latest (1.0.0+) build for aim and mst.

### DIFF
--- a/synth/docs/source/synthesizers/aim.rst
+++ b/synth/docs/source/synthesizers/aim.rst
@@ -4,8 +4,6 @@ Adaptive Iterative Mechanism (AIM)
 
  `AIM <https://arxiv.org/abs/2201.12677>`_ is a workload-adaptive algorithm, within the paradigm of algorithms that first selects a set of queries, then privately measures those queries, and finally generates synthetic data from the noisy measurements. It uses a set of innovative features to iteratively select the most useful measurements, reflecting both their relevance to the workload and their value in approximating the input data. AIM consistently outperforms a wide variety of existing mechanisms across a variety of experimental settings.
 
-Before using AIM, install `Private-PGM <https://github.com/ryan112358/private-pgm.git>`_ :
-
 .. code-block:: bash
 
   pip install git+https://github.com/ryan112358/private-pgm.git

--- a/synth/docs/source/synthesizers/mst.rst
+++ b/synth/docs/source/synthesizers/mst.rst
@@ -4,8 +4,6 @@ Maximum Spanning Tree (MST)
 
 MST achieves state of the art results for marginals over categorical data, and does well even with small source data.  From McKenna et al. "`Winning the NIST Contest: A scalable and general approach to differentially private synthetic data <https://arxiv.org/abs/2108.04978>`_"
 
-Before using MST, install `Private-PGM <https://github.com/ryan112358/private-pgm.git>`_ :
-
 .. code-block:: bash
 
   pip install git+https://github.com/ryan112358/private-pgm.git

--- a/synth/pyproject.toml
+++ b/synth/pyproject.toml
@@ -16,6 +16,7 @@ torch = {version = ">=2.2.0", optional = true}
 pac-synth = "^0.0.8"
 smartnoise-sql = "^1.0.5"
 Faker = ">=17.0.0"
+mbi = {git = "https://github.com/ryan112358/private-pgm.git", rev = "667facacbf29bd554c9a33e79bee57f1af2efa74"}
 
 [tool.poetry.dev-dependencies]
 

--- a/synth/snsynth/aim/aim.py
+++ b/synth/snsynth/aim/aim.py
@@ -1,32 +1,13 @@
 import numpy as np
 import pandas as pd
 
-try:
-    from mbi import FactoredInference, Dataset, Domain, GraphicalModel
-except ImportError:
-    print("Please install mbi with:\n   pip install git+https://github.com/ryan112358/private-pgm.git@01f02f17eba440f4e76c1d06fa5ee9eed0bd2bca")
-
+from mbi import Dataset, Domain, LinearMeasurement, estimation, MarkovRandomField, marginal_oracles
 import itertools
 from snsynth.base import Synthesizer
-from mbi import Dataset, FactoredInference, Domain
 from snsynth.utils import cdp_rho, exponential_mechanism, gaussian_noise, powerset
 from scipy import sparse
 
 prng = np.random
-
-
-class Identity(sparse.linalg.LinearOperator):
-    def __init__(self, n):
-        self.shape = (n,n)
-        self.dtype = np.float64
-    def _matmat(self, X):
-        return X
-    def __matmul__(self, X):
-        return X
-    def _transpose(self):
-        return self
-    def _adjoint(self):
-        return self
 
 def downward_closure(Ws):
     ans = set()
@@ -36,8 +17,9 @@ def downward_closure(Ws):
 
 
 def hypothetical_model_size(domain, cliques):
-    model = GraphicalModel(domain, cliques)
-    return model.size * 8 / 2 ** 20
+    """Estimate model size based on domain size and cliques"""
+    total_size = sum(domain.size(cl) for cl in cliques)
+    return total_size * 8 / 2 ** 20
 
 
 def compile_workload(workload):
@@ -69,7 +51,7 @@ class AIMSynthesizer(Synthesizer):
     :type verbose: bool
 
     Based on the code available in:
-    https://github.com/ryan112358/private-pgm/blob/master/mechanisms/aim.py
+    https://github.com/ryan112358/mbi/blob/master/mechanisms/aim.py
     """
 
     def __init__(self, epsilon=1., delta=1e-9, max_model_size=80, degree=2, num_marginals=None, max_cells: int = 10000,
@@ -135,8 +117,7 @@ class AIMSynthesizer(Synthesizer):
 
         self.rho = 0.0 if self.delta == 0.0 else cdp_rho(self.epsilon, self.delta)
 
-        data = pd.DataFrame(train_data, columns=colnames)
-        data = Dataset(df=data, domain=domain)
+        data = Dataset(pd.DataFrame(train_data, columns=colnames), domain=domain)
         workload = self.get_workload(
             data, degree=self.degree, max_cells=self.max_cells, num_marginals=self.num_marginals
         )
@@ -147,7 +128,11 @@ class AIMSynthesizer(Synthesizer):
         if samples is None:
             samples = self.num_rows
         data = self.synthesizer.synthetic_data(rows=samples)
-        data_iter = [tuple([c for c in t[1:]]) for t in data.df.itertuples()]
+
+        # need to reorder columns to match expected order
+        colnames = ["col" + str(i) for i in range(self._transformer.output_width)]
+        df = data.df[colnames]
+        data_iter = [tuple([c for c in t[1:]]) for t in df.itertuples()]
         return self._transformer.inverse_transform(data_iter)
 
     @staticmethod
@@ -179,6 +164,7 @@ class AIMSynthesizer(Synthesizer):
         # workload = [cl for cl, _ in W]
         candidates = compile_workload(workload)
         answers = {cl: data.project(cl).datavector() for cl in candidates}
+        total = float(len(data.df))
 
         oneway = [cl for cl in candidates if len(cl) == 1]
 
@@ -189,13 +175,11 @@ class AIMSynthesizer(Synthesizer):
         print('Initial Sigma', sigma)
         rho_used = len(oneway) * 0.5 / sigma ** 2
         for cl in oneway:
-            x = data.project(cl).datavector()
-            y = x + gaussian_noise(sigma, x.size)
-            I = Identity(y.size)
-            measurements.append((I, y, sigma, cl))
+            x = np.asarray(data.project(cl).datavector())
+            y = x + np.asarray(gaussian_noise(sigma, x.size))
+            measurements.append(LinearMeasurement(y, cl, sigma))
 
-        engine = FactoredInference(data.domain, iters=1000, warm_start=True)
-        model = engine.estimate(measurements)
+        model = estimation.mirror_descent(data.domain, measurements, known_total=total, iters=1000, marginal_oracle=marginal_oracles.message_passing_stable)
 
         t = 0
         terminate = False
@@ -215,13 +199,14 @@ class AIMSynthesizer(Synthesizer):
             cl = self._worst_approximated(small_candidates, answers, model, epsilon, sigma)
 
             n = data.domain.size(cl)
-            Q = Identity(n)
-            x = data.project(cl).datavector()
-            y = x + gaussian_noise(sigma, n)
-            measurements.append((Q, y, sigma, cl))
-            z = model.project(cl).datavector()
 
-            model = engine.estimate(measurements)
+            x = np.asarray(data.project(cl).datavector())
+            y = x + np.asarray(gaussian_noise(sigma, n))
+            z = model.project(cl).datavector()
+            measurements.append(LinearMeasurement(y, cl, sigma))
+
+            model = estimation.mirror_descent(data.domain, measurements, known_total=total, iters=1000, marginal_oracle=marginal_oracles.message_passing_stable)
+
             w = model.project(cl).datavector()
             if self.verbose:
                 print('Selected', cl, 'Size', n, 'Budget Used', rho_used / self.rho)
@@ -231,8 +216,8 @@ class AIMSynthesizer(Synthesizer):
                 sigma /= 2
                 epsilon *= 2
 
-        engine.iters = 2500
-        model = engine.estimate(measurements)
+        model = estimation.mirror_descent(data.domain, measurements, known_total=total, iters=1000, marginal_oracle=marginal_oracles.message_passing_stable)
+
 
         if self.verbose:
             print("Estimating marginals")

--- a/synth/snsynth/aim/aim.py
+++ b/synth/snsynth/aim/aim.py
@@ -164,7 +164,6 @@ class AIMSynthesizer(Synthesizer):
         # workload = [cl for cl, _ in W]
         candidates = compile_workload(workload)
         answers = {cl: data.project(cl).datavector() for cl in candidates}
-        total = float(len(data.df))
 
         oneway = [cl for cl in candidates if len(cl) == 1]
 
@@ -179,7 +178,7 @@ class AIMSynthesizer(Synthesizer):
             y = x + np.asarray(gaussian_noise(sigma, x.size))
             measurements.append(LinearMeasurement(y, cl, sigma))
 
-        model = estimation.mirror_descent(data.domain, measurements, known_total=total, iters=1000, marginal_oracle=marginal_oracles.message_passing_stable)
+        model = estimation.mirror_descent(data.domain, measurements, iters=1000, marginal_oracle=marginal_oracles.message_passing_stable)
 
         t = 0
         terminate = False
@@ -205,7 +204,7 @@ class AIMSynthesizer(Synthesizer):
             z = model.project(cl).datavector()
             measurements.append(LinearMeasurement(y, cl, sigma))
 
-            model = estimation.mirror_descent(data.domain, measurements, known_total=total, iters=1000, marginal_oracle=marginal_oracles.message_passing_stable)
+            model = estimation.mirror_descent(data.domain, measurements, iters=1000, marginal_oracle=marginal_oracles.message_passing_stable)
 
             w = model.project(cl).datavector()
             if self.verbose:
@@ -216,7 +215,7 @@ class AIMSynthesizer(Synthesizer):
                 sigma /= 2
                 epsilon *= 2
 
-        model = estimation.mirror_descent(data.domain, measurements, known_total=total, iters=1000, marginal_oracle=marginal_oracles.message_passing_stable)
+        model = estimation.mirror_descent(data.domain, measurements, iters=1000, marginal_oracle=marginal_oracles.message_passing_stable)
 
 
         if self.verbose:

--- a/synth/snsynth/mst/mst.py
+++ b/synth/snsynth/mst/mst.py
@@ -143,19 +143,6 @@ class MSTSynthesizer(Synthesizer):
     def compress_domain(self, data, measurements):
         supports = {}
         new_measurements = []
-        # for Q, y, sigma, proj in measurements:
-        #     col = proj[0]
-        #     sup = y >= 3*sigma
-        #     supports[col] = sup
-        #     if supports[col].sum() == y.size:
-        #         new_measurements.append((Q, y, sigma, proj))
-        #     else:  # need to re-express measurement over the new domain
-        #         y2 = np.append(y[sup], y[~sup].sum())
-        #         I2 = np.ones(y2.size)
-        #         I2[-1] = 1.0 / np.sqrt(y.size - y2.size + 1.0)
-        #         y2[-1] /= np.sqrt(y.size - y2.size + 1.0)
-        #         I2 = sparse.diags(I2)
-        #         new_measurements.append((I2, y2, sigma, proj))
         for m in measurements:
             y = np.asarray(m.noisy_measurement)
             sigma = m.stddev

--- a/synth/snsynth/mst/mst.py
+++ b/synth/snsynth/mst/mst.py
@@ -1,11 +1,7 @@
 import numpy as np
 import pandas as pd
 
-try:
-    from mbi import FactoredInference, Dataset, Domain
-except ImportError:
-    print("Please install mbi with:\n   pip install git+https://github.com/ryan112358/private-pgm.git@01f02f17eba440f4e76c1d06fa5ee9eed0bd2bca")
-    raise ImportError
+from mbi import Dataset, Domain, LinearMeasurement, estimation, marginal_oracles
 from scipy import sparse
 from disjoint_set import DisjointSet
 import networkx as nx
@@ -16,7 +12,7 @@ from snsynth.utils import cdp_rho, gaussian_noise
 
 """
 Wrapper for MST synthesizer from Private PGM:
-https://github.com/ryan112358/private-pgm/tree/e9ea5fcac62e2c5b92ae97f7afe2648c04432564
+https://github.com/ryan112358/mbi/tree/667facacbf29bd554c9a33e79bee57f1af2efa74
 
 This is a generalization of the winning mechanism from the
 2018 NIST Differential Privacy Synthetic Data Competition.
@@ -98,8 +94,7 @@ class MSTSynthesizer(Synthesizer):
         domain = Domain(colnames, cards)
         self.num_rows = len(data)
 
-        data = pd.DataFrame(train_data, columns=colnames)
-        data = Dataset(df=data, domain=domain)
+        data = Dataset(pd.DataFrame(train_data, columns=colnames).values, domain=domain)
 
         self.MST(data, self.epsilon, self.delta)
 
@@ -115,6 +110,7 @@ class MSTSynthesizer(Synthesizer):
         rho = cdp_rho(epsilon, delta)
         sigma = np.sqrt(3/(2*rho))
         cliques = [(col,) for col in data.domain]
+        total = len(data.df)
         if self.verbose:
             print("Getting cliques")
         log1 = self.measure(data, cliques, sigma)
@@ -123,12 +119,11 @@ class MSTSynthesizer(Synthesizer):
         # Here's the decompress function
         self.undo_compress_fn = undo_compress_fn
 
-        cliques = self.select(data, rho/3.0, log1)
+        cliques = self.select(data, rho/3.0, log1, total)
         log2 = self.measure(data, cliques, sigma)
-        engine = FactoredInference(data.domain, iters=5000)
         if self.verbose:
             print("Estimating marginals")
-        est = engine.estimate(log1+log2)
+        est = estimation.mirror_descent(data.domain, log1+log2, known_total=float(total), iters=5000, marginal_oracle=marginal_oracles.message_passing_stable)
 
         # Here's the synthesizer
 
@@ -140,28 +135,60 @@ class MSTSynthesizer(Synthesizer):
         weights = np.array(weights) / np.linalg.norm(weights)
         measurements = []
         for proj, wgt in zip(cliques, weights):
-            x = data.project(proj).datavector()
-            y = x + gaussian_noise(sigma/wgt, x.size)
-            Q = sparse.eye(x.size)
-            measurements.append((Q, y, sigma/wgt, proj))
+            x = np.asarray(data.project(proj).datavector())
+            y = x + np.array(gaussian_noise(sigma/wgt, x.size))
+            measurements.append(LinearMeasurement(y, proj, sigma/wgt))
         return measurements
 
     def compress_domain(self, data, measurements):
         supports = {}
         new_measurements = []
-        for Q, y, sigma, proj in measurements:
+        # for Q, y, sigma, proj in measurements:
+        #     col = proj[0]
+        #     sup = y >= 3*sigma
+        #     supports[col] = sup
+        #     if supports[col].sum() == y.size:
+        #         new_measurements.append((Q, y, sigma, proj))
+        #     else:  # need to re-express measurement over the new domain
+        #         y2 = np.append(y[sup], y[~sup].sum())
+        #         I2 = np.ones(y2.size)
+        #         I2[-1] = 1.0 / np.sqrt(y.size - y2.size + 1.0)
+        #         y2[-1] /= np.sqrt(y.size - y2.size + 1.0)
+        #         I2 = sparse.diags(I2)
+        #         new_measurements.append((I2, y2, sigma, proj))
+        for m in measurements:
+            y = np.asarray(m.noisy_measurement)
+            sigma = m.stddev
+            proj = m.clique
             col = proj[0]
             sup = y >= 3*sigma
-            supports[col] = sup
-            if supports[col].sum() == y.size:
-                new_measurements.append((Q, y, sigma, proj))
-            else:  # need to re-express measurement over the new domain
-                y2 = np.append(y[sup], y[~sup].sum())
-                I2 = np.ones(y2.size)
-                I2[-1] = 1.0 / np.sqrt(y.size - y2.size + 1.0)
-                y2[-1] /= np.sqrt(y.size - y2.size + 1.0)
-                I2 = sparse.diags(I2)
-                new_measurements.append((I2, y2, sigma, proj))
+            
+            # skip compression if it would result in less than 2 bits
+            num_kept = sup.sum()
+            if num_kept < 2 and y.size >= 2:
+                supports[col] = np.ones(y.size, dtype=bool)
+                new_measurements.append(m)
+            elif supports.get(col) is None or num_kept == y.size:
+                supports[col] = sup if num_kept >= 2 else np.ones(y.size, dtype=bool)
+                if num_kept == y.size:
+                    new_measurements.append(m)
+                else:  # need to re-express measurement over the new domain
+                    y2 = np.append(y[sup], y[~sup].sum())
+                    scale_factor = 1.0 / np.sqrt(y.size - num_kept + 1.0)
+                    y2[-1] *= scale_factor
+                    new_measurements.append(LinearMeasurement(y2, proj, sigma))
+            else:
+                supports[col] = sup
+                if sup.sum() == y.size:
+                    new_measurements.append(m)
+                else:
+                    y2 = np.append(y[sup], y[~sup].sum())
+                    scale_factor = 1.0 / np.sqrt(y.size - sup.sum() + 1.0)
+                    y2[-1] *= scale_factor
+                    new_measurements.append(LinearMeasurement(y2, proj, sigma))
+
+
+
 
         undo_compress_fn = lambda data: self.reverse_data(data, supports)  # noqa: E731
 
@@ -173,9 +200,8 @@ class MSTSynthesizer(Synthesizer):
         probas = np.exp(scores - logsumexp(scores))
         return prng.choice(q.size, p=probas)
 
-    def select(self, data, rho, measurement_log, cliques=[]):
-        engine = FactoredInference(data.domain, iters=1000)
-        est = engine.estimate(measurement_log)
+    def select(self, data, rho, measurement_log, total, cliques=[]):
+        est = estimation.mirror_descent(data.domain, measurement_log, known_total=float(total), iters=1000, marginal_oracle=marginal_oracles.message_passing_stable)
 
         weights = {}
         candidates = list(itertools.combinations(data.domain.attrs, 2))

--- a/synth/tests/requirements.txt
+++ b/synth/tests/requirements.txt
@@ -5,4 +5,4 @@ mlflow
 scikit-learn
 numpy
 pytest
-git+https://github.com/ryan112358/private-pgm.git@01f02f17eba440f4e76c1d06fa5ee9eed0bd2bca
+git+https://github.com/ryan112358/private-pgm.git@667facacbf29bd554c9a33e79bee57f1af2efa74


### PR DESCRIPTION
## Summary

Updates `mst.py` and `aim.py` to use the latest development build from MBI. The commit that smartnoise is using is about 3 years old and uses an outdated interface for the library (See https://github.com/ryan112358/mbi/issues/26). MBI has undergone significant development and this brings in the very latest changes. 

I intended to use the `v1.0.0` release of MBI from pypi but ran into a bug related `jax.jit`. This bug was fixed in https://github.com/ryan112358/mbi/pull/85 but a new release of MBI has yet to be put out. There were some minor changes between the API of `v1.0.0` and the latest development build (Dataset API). I don't know if there are bigger plans for a v1.1 of MBI but because of the jax issue this is the earliest commit that will work. 

Changes
* Updated MBI dependency
* Added MBI to pyproject.toml
* Updated documentation notes about MBI installation
* Replaced FactoredInterface (now missing) with `estimation.mirror_descent()`
* Replaced the tuple measurements (`Q`, `y`, `sigma`, `proj`) with new `LinearMeasurement`
* Replaced FactoredInterface with MarkovRandomField for aim. 
* Numpy arrays converted to jax arrays as needed

## Help Wanted
*  I did a little smoke test to test out the LinearMeasurement and I was happy with the results. I think it would be helpful for someone else to independently test the implementation to see if they get the same results. 
* We should do a new release of smartnoise. Not sure if we want to wait for a v1.1 of MBI or just release it now. Also, I think this might warrant a minor version bump but wanted to see what the maintainers were thinking.  
* I ran the tests `test_aim.py` and `test_mst.py` but there are only a couple of cases. Maybe we should add a more through test case? 

## Next Steps
* Release new version