### PR TITLE
Update email in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ If you believe you have found a security vulnerability in any OpenDP repository,
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-Instead, please report them to us via email at info@opendp.org.
+Instead, please report them to us via email at security@opendp.org.
 
 You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message.
 


### PR DESCRIPTION
We are moving away from info@opendp.org.